### PR TITLE
Fix Avalonia.Controls.DataGrid package reference

### DIFF
--- a/src/Consolonia.Core/Consolonia.Core.csproj
+++ b/src/Consolonia.Core/Consolonia.Core.csproj
@@ -9,12 +9,7 @@
       <PackageReference Include="Avalonia.FreeDesktop" Version="0.10.3" />
       <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.3" />
       <PackageReference Include="Avalonia.Skia" Version="0.10.3" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="Avalonia.Controls.DataGrid, Version=0.10.3.0, Culture=neutral, PublicKeyToken=c8d484a7012f9a8b">
-        <HintPath>..\..\..\..\.nuget\packages\avalonia.controls.datagrid\0.10.3\lib\netstandard2.0\Avalonia.Controls.DataGrid.dll</HintPath>
-      </Reference>
+      <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.10.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When trying to build Example project I get:
```
  DataGrid.axaml(112, 18): [XAMLIL] Unable to resolve type DataGridFrozenGrid from namespace https://github.com/avaloniaui Line 112, position 18.
```
this PR fixes that.