### PR TITLE
turn on utf8 encoding for DefaultConsole and Windows Console.

### DIFF
--- a/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
@@ -21,7 +21,7 @@ namespace Consolonia.Core.Infrastructure
         private readonly IKeyboardDevice _myKeyboardDevice;
         [NotNull] internal readonly IConsole Console;
         private IInputRoot _inputRoot;
-        private CancellationTokenSource? _resizeCancellationTokenSource;
+        private CancellationTokenSource _resizeCancellationTokenSource;
         private readonly TimeSpan _resizeDelay = TimeSpan.FromMilliseconds(50);
 
         public ConsoleWindow()

--- a/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
@@ -22,7 +22,7 @@ namespace Consolonia.Core.Infrastructure
         [NotNull] internal readonly IConsole Console;
         private IInputRoot _inputRoot;
         private CancellationTokenSource _resizeCancellationTokenSource;
-        private readonly TimeSpan _resizeDelay = TimeSpan.FromMilliseconds(50);
+        private readonly TimeSpan _resizeDelay = TimeSpan.FromMilliseconds(100);
 
         public ConsoleWindow()
         {

--- a/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
@@ -303,8 +303,10 @@ namespace Consolonia.Core.Infrastructure
             System.Console.Clear();
 
             // Cancel previous task if there is one and start a new one
-            _resizeCancellationTokenSource?.Cancel();
+            var oldCts = _resizeCancellationTokenSource;
             _resizeCancellationTokenSource = new CancellationTokenSource();
+            oldCts?.Cancel();
+            oldCts?.Dispose();
 
             // start a task which if no resize event comes for _resizeDelay will post the resize to the window
             Task.Run(async () =>

--- a/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
@@ -19,10 +19,10 @@ namespace Consolonia.Core.Infrastructure
     internal class ConsoleWindow : IWindowImpl
     {
         private readonly IKeyboardDevice _myKeyboardDevice;
+        private readonly TimeSpan _resizeDelay = TimeSpan.FromMilliseconds(100);
         [NotNull] internal readonly IConsole Console;
         private IInputRoot _inputRoot;
         private CancellationTokenSource _resizeCancellationTokenSource;
-        private readonly TimeSpan _resizeDelay = TimeSpan.FromMilliseconds(100);
 
         public ConsoleWindow()
         {
@@ -303,7 +303,7 @@ namespace Consolonia.Core.Infrastructure
             System.Console.Clear();
 
             // Cancel previous task if there is one and start a new one
-            var oldCts = _resizeCancellationTokenSource;
+            CancellationTokenSource oldCts = _resizeCancellationTokenSource;
             _resizeCancellationTokenSource = new CancellationTokenSource();
             oldCts?.Cancel();
             oldCts?.Dispose();

--- a/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -19,6 +21,8 @@ namespace Consolonia.Core.Infrastructure
         private readonly IKeyboardDevice _myKeyboardDevice;
         [NotNull] internal readonly IConsole Console;
         private IInputRoot _inputRoot;
+        private CancellationTokenSource? _resizeCancellationTokenSource;
+        private readonly TimeSpan _resizeDelay = TimeSpan.FromMilliseconds(50);
 
         public ConsoleWindow()
         {
@@ -295,11 +299,33 @@ namespace Consolonia.Core.Infrastructure
 
         private void OnConsoleOnResized()
         {
-            Dispatcher.UIThread.Post(() =>
+            // clear screen so we don't see crazy while resizing.
+            System.Console.Clear();
+
+            // Cancel previous task if there is one and start a new one
+            _resizeCancellationTokenSource?.Cancel();
+            _resizeCancellationTokenSource = new CancellationTokenSource();
+
+            // start a task which if no resize event comes for _resizeDelay will post the resize to the window
+            Task.Run(async () =>
             {
-                PixelBufferSize pixelBufferSize = Console.Size;
-                var size = new Size(pixelBufferSize.Width, pixelBufferSize.Height);
-                Resized!(size, WindowResizeReason.Unspecified);
+                try
+                {
+                    // Wait for the delay period, this task will be canceled if another refresh comes in.
+                    await Task.Delay(_resizeDelay, _resizeCancellationTokenSource.Token).ConfigureAwait(false);
+
+                    // dispatch to the UI thread 
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        PixelBufferSize pixelBufferSize = Console.Size;
+                        var size = new Size(pixelBufferSize.Width, pixelBufferSize.Height);
+                        Resized!(size, WindowResizeReason.Unspecified);
+                    });
+                }
+                catch (TaskCanceledException)
+                {
+                    // Ignore cancellation exception, we want this to happen while resizes are happening quickly
+                }
             });
         }
 

--- a/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
@@ -41,6 +41,8 @@ namespace Consolonia.Core.Infrastructure
 
         public DefaultNetConsole()
         {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+
             StartSizeCheckTimerAsync();
             StartInputReading();
         }

--- a/src/Consolonia.PlatformSupport/WindowsConsole.cs
+++ b/src/Consolonia.PlatformSupport/WindowsConsole.cs
@@ -55,6 +55,8 @@ namespace Consolonia.PlatformSupport
 
         public Win32Console()
         {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+
             _windowsConsole = new WindowsConsole();
 
             StartEventLoop();


### PR DESCRIPTION
See discussion https://github.com/jinek/Consolonia/discussions/129 for details 

Also added clear of screen while resizing and delay rendering to more both be more efficient and get rid of unsightly tears while resizing.
![DelayDraw](https://github.com/user-attachments/assets/e9d10b1a-ddb1-44d1-9887-b4160967e054)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced console output encoding to UTF-8 for better character handling.
	- Improved responsiveness of the console window during resizing events.

- **Bug Fixes**
	- Enhanced error handling in the console input methods, addressing potential issues during input processing.

- **Refactor**
	- Updated methods for better input handling and console event processing without changing core logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->