### PR TITLE
Add Italic, strikethrough and fix line draw bug 

### DIFF
--- a/src/Consolonia.Core/Consolonia.Core.csproj
+++ b/src/Consolonia.Core/Consolonia.Core.csproj
@@ -6,7 +6,6 @@
         <PackageReference Include="Avalonia.FreeDesktop" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Avalonia.Skia" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Crayon" Version="2.0.69" />
         <PackageReference Include="NullLib.ConsoleEx" Version="1.0.4.4" />
         <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.8" />
     </ItemGroup>

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -146,7 +146,7 @@ namespace Consolonia.Core.Drawing
                         CurrentClip.ExecuteWithClipping(new Point(px, py), () =>
                         {
                             _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
-                                (pixel, bb) => { return pixel.Blend(new Pixel(new PixelBackground(bb.Mode, bb.Color))); },
+                                (pixel, bb) => pixel.Blend(new Pixel(new PixelBackground(bb.Mode, bb.Color))),
                                 backgroundBrush);
                         });
                     }
@@ -289,7 +289,6 @@ namespace Consolonia.Core.Drawing
 
             byte pattern = (byte)(line.Vertical ? 0b1010 : 0b0101);
             DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, line.Length); //line
-            return;
         }
 
         /// <summary>
@@ -322,7 +321,6 @@ namespace Consolonia.Core.Drawing
 
             pattern = (byte)(line.Vertical ? 0b1000 : 0b0001);
             DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, 1); //ending 
-            return;
         }
 
         /// <summary>

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -324,7 +324,7 @@ namespace Consolonia.Core.Drawing
             DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, 1); //beginning
 
             pattern = line.Vertical ? VerticalLinePattern : HorizontalLinePattern;
-            DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, line.Length - 2); //line
+            DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, line.Length - 1); //line
 
             pattern = line.Vertical ? VerticalEndPattern : HorizontalEndPattern;
             DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, 1); //ending 

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -344,14 +344,12 @@ namespace Consolonia.Core.Drawing
         /// <returns></returns>
         private bool IfMoveConsoleCaretMove(IPen pen, Point head)
         {
-            if (pen.Brush is MoveConsoleCaretToPositionBrush)
-            {
-                CurrentClip.ExecuteWithClipping(head,
-                    () => { _pixelBuffer.Set((PixelBufferCoordinate)head, pixel => pixel.Blend(new Pixel(true))); });
-                return true;
-            }
-
-            return false;
+            if (pen.Brush is not MoveConsoleCaretToPositionBrush)
+                return false;
+                
+            CurrentClip.ExecuteWithClipping(head,
+                () => { _pixelBuffer.Set((PixelBufferCoordinate)head, pixel => pixel.Blend(new Pixel(true))); });
+            return true;
         }
 
         /// <summary>

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -61,20 +61,20 @@ namespace Consolonia.Core.Drawing
             int width = bitmap.Info.Width;
             int height = bitmap.Info.Height;
             for (int x = 0; x < width; x++)
-                for (int y = 0; y < height; y++)
-                {
-                    int px = (int)targetRect.TopLeft.X + x;
-                    int py = (int)targetRect.TopLeft.Y + y;
-                    SKColor skColor = bitmap.GetPixel(x, y);
-                    Color color = Color.FromRgb(skColor.Red, skColor.Green, skColor.Blue);
-                    var imagePixel = new Pixel('█', color);
-                    CurrentClip.ExecuteWithClipping(new Point(px, py),
-                        () =>
-                        {
-                            _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
-                                (existingPixel, _) => existingPixel.Blend(imagePixel), imagePixel.Background.Color);
-                        });
-                }
+            for (int y = 0; y < height; y++)
+            {
+                int px = (int)targetRect.TopLeft.X + x;
+                int py = (int)targetRect.TopLeft.Y + y;
+                SKColor skColor = bitmap.GetPixel(x, y);
+                Color color = Color.FromRgb(skColor.Red, skColor.Green, skColor.Blue);
+                var imagePixel = new Pixel('█', color);
+                CurrentClip.ExecuteWithClipping(new Point(px, py),
+                    () =>
+                    {
+                        _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
+                            (existingPixel, _) => existingPixel.Blend(imagePixel), imagePixel.Background.Color);
+                    });
+            }
         }
 
         public void DrawBitmap(IBitmapImpl source, IBrush opacityMask, Rect opacityMaskRect, Rect destRect)
@@ -125,11 +125,11 @@ namespace Consolonia.Core.Drawing
                     case VisualBrush:
                         throw new NotImplementedException();
                     case ISceneBrush sceneBrush:
-                        {
-                            ISceneBrushContent sceneBrushContent = sceneBrush.CreateContent();
-                            if (sceneBrushContent != null) sceneBrushContent.Render(this, Matrix.Identity);
-                            return;
-                        }
+                    {
+                        ISceneBrushContent sceneBrushContent = sceneBrush.CreateContent();
+                        if (sceneBrushContent != null) sceneBrushContent.Render(this, Matrix.Identity);
+                        return;
+                    }
                 }
 
                 Rect r2 = r.TransformToAABB(Transform);
@@ -137,19 +137,19 @@ namespace Consolonia.Core.Drawing
                 double width = r2.Width + (pen?.Thickness ?? 0);
                 double height = r2.Height + (pen?.Thickness ?? 0);
                 for (int x = 0; x < width; x++)
-                    for (int y = 0; y < height; y++)
-                    {
-                        int px = (int)(r2.TopLeft.X + x);
-                        int py = (int)(r2.TopLeft.Y + y);
+                for (int y = 0; y < height; y++)
+                {
+                    int px = (int)(r2.TopLeft.X + x);
+                    int py = (int)(r2.TopLeft.Y + y);
 
-                        ConsoleBrush backgroundBrush = ConsoleBrush.FromPosition(brush, x, y, (int)width, (int)height);
-                        CurrentClip.ExecuteWithClipping(new Point(px, py), () =>
-                        {
-                            _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
-                                (pixel, bb) => pixel.Blend(new Pixel(new PixelBackground(bb.Mode, bb.Color))),
-                                backgroundBrush);
-                        });
-                    }
+                    ConsoleBrush backgroundBrush = ConsoleBrush.FromPosition(brush, x, y, (int)width, (int)height);
+                    CurrentClip.ExecuteWithClipping(new Point(px, py), () =>
+                    {
+                        _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
+                            (pixel, bb) => pixel.Blend(new Pixel(new PixelBackground(bb.Mode, bb.Color))),
+                            backgroundBrush);
+                    });
+                }
             }
 
             if (pen is null or { Thickness: 0 }
@@ -266,7 +266,7 @@ namespace Consolonia.Core.Drawing
         }
 
         /// <summary>
-        /// Draw a straight horizontal line or vertical line
+        ///     Draw a straight horizontal line or vertical line
         /// </summary>
         /// <param name="pen">pen</param>
         /// <param name="line">line</param>
@@ -292,16 +292,16 @@ namespace Consolonia.Core.Drawing
         }
 
         /// <summary>
-        /// Draw a rectangle line with corners
+        ///     Draw a rectangle line with corners
         /// </summary>
         /// <param name="pen">pen</param>
         /// <param name="line">line</param>
         private void DrawRectangleLineInternal(IPen pen, Line line)
         {
             if (pen.Thickness == 0) return;
-            
+
             line = TransformLineInternal(line);
-            
+
             Point head = line.PStart;
 
             if (IfMoveConsoleCaretMove(pen, head))
@@ -324,7 +324,7 @@ namespace Consolonia.Core.Drawing
         }
 
         /// <summary>
-        /// Transform line coordinates
+        ///     Transform line coordinates
         /// </summary>
         /// <param name="line"></param>
         /// <returns></returns>
@@ -337,7 +337,7 @@ namespace Consolonia.Core.Drawing
         }
 
         /// <summary>
-        /// If the pen brush is a MoveConsoleCaretToPositionBrush, move the caret
+        ///     If the pen brush is a MoveConsoleCaretToPositionBrush, move the caret
         /// </summary>
         /// <param name="pen"></param>
         /// <param name="head"></param>
@@ -346,15 +346,16 @@ namespace Consolonia.Core.Drawing
         {
             if (pen.Brush is MoveConsoleCaretToPositionBrush)
             {
-                CurrentClip.ExecuteWithClipping(head, 
+                CurrentClip.ExecuteWithClipping(head,
                     () => { _pixelBuffer.Set((PixelBufferCoordinate)head, pixel => pixel.Blend(new Pixel(true))); });
                 return true;
             }
+
             return false;
         }
 
         /// <summary>
-        /// Extract color from pen brush
+        ///     Extract color from pen brush
         /// </summary>
         /// <param name="pen"></param>
         /// <param name="lineStyle"></param>
@@ -396,7 +397,7 @@ namespace Consolonia.Core.Drawing
         }
 
         /// <summary>
-        /// Draw pixels for a line with linestyle and a pattern
+        ///     Draw pixels for a line with linestyle and a pattern
         /// </summary>
         /// <param name="head">the current caret position</param>
         /// <param name="line">line to render</param>
@@ -404,11 +405,12 @@ namespace Consolonia.Core.Drawing
         /// <param name="pattern">pattern of character to use</param>
         /// <param name="color">color for char</param>
         /// <param name="count">number of chars</param>
-        private void DrawPixelAndMoveHead(ref Point head, Line line, LineStyle? lineStyle, byte pattern, Color color, int count)
+        private void DrawPixelAndMoveHead(ref Point head, Line line, LineStyle? lineStyle, byte pattern, Color color,
+            int count)
         {
             for (int i = 0; i < count; i++)
             {
-                var h = head;
+                Point h = head;
                 CurrentClip.ExecuteWithClipping(h, () =>
                 {
                     // ReSharper disable once AccessToModifiedClosure todo: pass as a parameter
@@ -447,43 +449,43 @@ namespace Consolonia.Core.Drawing
                 switch (c)
                 {
                     case '\t':
+                    {
+                        const int tabSize = 8;
+                        var consolePixel = new Pixel(' ', foregroundColor);
+                        for (int j = 0; j < tabSize; j++)
                         {
-                            const int tabSize = 8;
-                            var consolePixel = new Pixel(' ', foregroundColor);
-                            for (int j = 0; j < tabSize; j++)
+                            Point newCharacterPoint = characterPoint.WithX(characterPoint.X + j);
+                            CurrentClip.ExecuteWithClipping(newCharacterPoint, () =>
                             {
-                                Point newCharacterPoint = characterPoint.WithX(characterPoint.X + j);
-                                CurrentClip.ExecuteWithClipping(newCharacterPoint, () =>
-                                {
-                                    _pixelBuffer.Set((PixelBufferCoordinate)newCharacterPoint,
-                                        (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);
-                                });
-                            }
-
-                            currentXPosition += tabSize - 1;
+                                _pixelBuffer.Set((PixelBufferCoordinate)newCharacterPoint,
+                                    (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);
+                            });
                         }
+
+                        currentXPosition += tabSize - 1;
+                    }
                         break;
                     case '\n':
-                        {
-                            /* it's not clear if we need to draw anything. Cursor can be placed at the end of the line
-                             var consolePixel =  new Pixel(' ', foregroundColor);
+                    {
+                        /* it's not clear if we need to draw anything. Cursor can be placed at the end of the line
+                         var consolePixel =  new Pixel(' ', foregroundColor);
 
-                            _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
-                                (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);*/
-                        }
+                        _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
+                            (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);*/
+                    }
                         break;
                     case '\u200B':
                         currentXPosition--;
                         break;
                     default:
+                    {
+                        var consolePixel = new Pixel(c, foregroundColor, typeface.Style, typeface.Weight);
+                        CurrentClip.ExecuteWithClipping(characterPoint, () =>
                         {
-                            var consolePixel = new Pixel(c, foregroundColor, typeface.Style, typeface.Weight);
-                            CurrentClip.ExecuteWithClipping(characterPoint, () =>
-                            {
-                                _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
-                                    (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);
-                            });
-                        }
+                            _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
+                                (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);
+                        });
+                    }
                         break;
                 }
             }

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -61,20 +61,20 @@ namespace Consolonia.Core.Drawing
             int width = bitmap.Info.Width;
             int height = bitmap.Info.Height;
             for (int x = 0; x < width; x++)
-            for (int y = 0; y < height; y++)
-            {
-                int px = (int)targetRect.TopLeft.X + x;
-                int py = (int)targetRect.TopLeft.Y + y;
-                SKColor skColor = bitmap.GetPixel(x, y);
-                Color color = Color.FromRgb(skColor.Red, skColor.Green, skColor.Blue);
-                var imagePixel = new Pixel('█', color);
-                CurrentClip.ExecuteWithClipping(new Point(px, py),
-                    () =>
-                    {
-                        _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
-                            (existingPixel, _) => existingPixel.Blend(imagePixel), imagePixel.Background.Color);
-                    });
-            }
+                for (int y = 0; y < height; y++)
+                {
+                    int px = (int)targetRect.TopLeft.X + x;
+                    int py = (int)targetRect.TopLeft.Y + y;
+                    SKColor skColor = bitmap.GetPixel(x, y);
+                    Color color = Color.FromRgb(skColor.Red, skColor.Green, skColor.Blue);
+                    var imagePixel = new Pixel('█', color);
+                    CurrentClip.ExecuteWithClipping(new Point(px, py),
+                        () =>
+                        {
+                            _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
+                                (existingPixel, _) => existingPixel.Blend(imagePixel), imagePixel.Background.Color);
+                        });
+                }
         }
 
         public void DrawBitmap(IBitmapImpl source, IBrush opacityMask, Rect opacityMaskRect, Rect destRect)
@@ -125,11 +125,11 @@ namespace Consolonia.Core.Drawing
                     case VisualBrush:
                         throw new NotImplementedException();
                     case ISceneBrush sceneBrush:
-                    {
-                        ISceneBrushContent sceneBrushContent = sceneBrush.CreateContent();
-                        if (sceneBrushContent != null) sceneBrushContent.Render(this, Matrix.Identity);
-                        return;
-                    }
+                        {
+                            ISceneBrushContent sceneBrushContent = sceneBrush.CreateContent();
+                            if (sceneBrushContent != null) sceneBrushContent.Render(this, Matrix.Identity);
+                            return;
+                        }
                 }
 
                 Rect r2 = r.TransformToAABB(Transform);
@@ -137,28 +137,28 @@ namespace Consolonia.Core.Drawing
                 double width = r2.Width + (pen?.Thickness ?? 0);
                 double height = r2.Height + (pen?.Thickness ?? 0);
                 for (int x = 0; x < width; x++)
-                for (int y = 0; y < height; y++)
-                {
-                    int px = (int)(r2.TopLeft.X + x);
-                    int py = (int)(r2.TopLeft.Y + y);
-
-                    ConsoleBrush backgroundBrush = ConsoleBrush.FromPosition(brush, x, y, (int)width, (int)height);
-                    CurrentClip.ExecuteWithClipping(new Point(px, py), () =>
+                    for (int y = 0; y < height; y++)
                     {
-                        _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
-                            (pixel, bb) => { return pixel.Blend(new Pixel(new PixelBackground(bb.Mode, bb.Color))); },
-                            backgroundBrush);
-                    });
-                }
+                        int px = (int)(r2.TopLeft.X + x);
+                        int py = (int)(r2.TopLeft.Y + y);
+
+                        ConsoleBrush backgroundBrush = ConsoleBrush.FromPosition(brush, x, y, (int)width, (int)height);
+                        CurrentClip.ExecuteWithClipping(new Point(px, py), () =>
+                        {
+                            _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
+                                (pixel, bb) => { return pixel.Blend(new Pixel(new PixelBackground(bb.Mode, bb.Color))); },
+                                backgroundBrush);
+                        });
+                    }
             }
 
             if (pen is null or { Thickness: 0 }
                 or { Brush: null }) return;
 
-            DrawLineInternal(pen, new Line(r.TopLeft, false, (int)r.Width));
-            DrawLineInternal(pen, new Line(r.BottomLeft, false, (int)r.Width));
-            DrawLineInternal(pen, new Line(r.TopLeft, true, (int)r.Height));
-            DrawLineInternal(pen, new Line(r.TopRight, true, (int)r.Height));
+            DrawRectangleLineInternal(pen, new Line(r.TopLeft, false, (int)r.Width));
+            DrawRectangleLineInternal(pen, new Line(r.BottomLeft, false, (int)r.Width));
+            DrawRectangleLineInternal(pen, new Line(r.TopLeft, true, (int)r.Height));
+            DrawRectangleLineInternal(pen, new Line(r.TopRight, true, (int)r.Height));
         }
 
         public void DrawEllipse(IBrush brush, IPen pen, Rect rect)
@@ -265,6 +265,103 @@ namespace Consolonia.Core.Drawing
             set => _transform = value * _postTransform;
         }
 
+        /// <summary>
+        /// Draw a straight horizontal line or vertical line
+        /// </summary>
+        /// <param name="pen">pen</param>
+        /// <param name="line">line</param>
+        private void DrawLineInternal(IPen pen, Line line)
+        {
+            if (pen.Thickness == 0) return;
+
+            line = TransformLineInternal(line);
+
+            Point head = line.PStart;
+
+            if (IfMoveConsoleCaretMove(pen, head))
+                return;
+
+            var extractColorCheckPlatformSupported = ExtractColorOrNullWithPlatformCheck(pen, out var lineStyle);
+            if (extractColorCheckPlatformSupported == null)
+                return;
+
+            var color = (Color)extractColorCheckPlatformSupported;
+
+            byte pattern = (byte)(line.Vertical ? 0b1010 : 0b0101);
+            DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, line.Length); //line
+            return;
+        }
+
+        /// <summary>
+        /// Draw a rectangle line with corners
+        /// </summary>
+        /// <param name="pen">pen</param>
+        /// <param name="line">line</param>
+        private void DrawRectangleLineInternal(IPen pen, Line line)
+        {
+            if (pen.Thickness == 0) return;
+            
+            line = TransformLineInternal(line);
+            
+            Point head = line.PStart;
+
+            if (IfMoveConsoleCaretMove(pen, head))
+                return;
+
+            var extractColorCheckPlatformSupported = ExtractColorOrNullWithPlatformCheck(pen, out var lineStyle);
+            if (extractColorCheckPlatformSupported == null)
+                return;
+
+            var color = (Color)extractColorCheckPlatformSupported;
+
+            byte pattern = (byte)(line.Vertical ? 0b0010 : 0b0100);
+            DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, 1); //beginning
+
+            pattern = (byte)(line.Vertical ? 0b1010 : 0b0101);
+            DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, line.Length - 1); //line
+
+            pattern = (byte)(line.Vertical ? 0b1000 : 0b0001);
+            DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, 1); //ending 
+            return;
+        }
+
+        /// <summary>
+        /// Transform line coordinates
+        /// </summary>
+        /// <param name="line"></param>
+        /// <returns></returns>
+        private Line TransformLineInternal(Line line)
+        {
+            if (!Transform.NoRotation()) ConsoloniaPlatform.RaiseNotSupported(16);
+
+            line = (Line)line.WithTransform(Transform);
+            return line;
+        }
+
+        /// <summary>
+        /// If the pen brush is a MoveConsoleCaretToPositionBrush, move the caret
+        /// </summary>
+        /// <param name="pen"></param>
+        /// <param name="head"></param>
+        /// <returns></returns>
+        private bool IfMoveConsoleCaretMove(IPen pen, Point head)
+        {
+            if (pen.Brush is MoveConsoleCaretToPositionBrush)
+            {
+                CurrentClip.ExecuteWithClipping(head, 
+                    () => { _pixelBuffer.Set((PixelBufferCoordinate)head, pixel => pixel.Blend(new Pixel(true))); });
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Extract color from pen brush
+        /// </summary>
+        /// <param name="pen"></param>
+        /// <param name="lineStyle"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         private static Color? ExtractColorOrNullWithPlatformCheck(IPen pen, out LineStyle? lineStyle)
         {
             lineStyle = null;
@@ -300,58 +397,32 @@ namespace Consolonia.Core.Drawing
             }
         }
 
-        private void DrawLineInternal(IPen pen, Line line)
+        /// <summary>
+        /// Draw pixels for a line with linestyle and a pattern
+        /// </summary>
+        /// <param name="head">the current caret position</param>
+        /// <param name="line">line to render</param>
+        /// <param name="lineStyle">line style</param>
+        /// <param name="pattern">pattern of character to use</param>
+        /// <param name="color">color for char</param>
+        /// <param name="count">number of chars</param>
+        private void DrawPixelAndMoveHead(ref Point head, Line line, LineStyle? lineStyle, byte pattern, Color color, int count)
         {
-            if (pen.Thickness == 0) return;
-
-            if (!Transform.NoRotation()) ConsoloniaPlatform.RaiseNotSupported(16);
-
-            line = (Line)line.WithTransform(Transform);
-
-            Point head = line.PStart;
-
-            if (pen.Brush is MoveConsoleCaretToPositionBrush)
+            for (int i = 0; i < count; i++)
             {
-                CurrentClip.ExecuteWithClipping(head,
-                    () => { _pixelBuffer.Set((PixelBufferCoordinate)head, pixel => pixel.Blend(new Pixel(true))); });
-
-                return;
-            }
-
-            var extractColorCheckPlatformSupported =
-                ExtractColorOrNullWithPlatformCheck(pen, out var lineStyle);
-            if (extractColorCheckPlatformSupported == null)
-                return;
-
-            var consoleColor = (Color)extractColorCheckPlatformSupported;
-
-            byte pattern = (byte)(line.Vertical ? 0b0010 : 0b0100);
-            DrawPixelAndMoveHead(1); //beginning
-
-            pattern = (byte)(line.Vertical ? 0b1010 : 0b0101);
-            DrawPixelAndMoveHead(line.Length - 1); //line
-
-            pattern = (byte)(line.Vertical ? 0b1000 : 0b0001);
-            DrawPixelAndMoveHead(1); //ending 
-            return;
-
-            void DrawPixelAndMoveHead(int count)
-            {
-                for (int i = 0; i < count; i++)
+                var h = head;
+                CurrentClip.ExecuteWithClipping(h, () =>
                 {
-                    CurrentClip.ExecuteWithClipping(head, () =>
-                    {
-                        // ReSharper disable once AccessToModifiedClosure todo: pass as a parameter
-                        _pixelBuffer.Set((PixelBufferCoordinate)head,
-                            (pixel, mcC) => pixel.Blend(new Pixel(DrawingBoxSymbol.UpRightDownLeftFromPattern(
-                                mcC.pattern,
-                                lineStyle ?? LineStyle.SingleLine), mcC.consoleColor)),
-                            (pattern, consoleColor));
-                    });
-                    head = line.Vertical
-                        ? head.WithY(head.Y + 1)
-                        : head.WithX(head.X + 1);
-                }
+                    // ReSharper disable once AccessToModifiedClosure todo: pass as a parameter
+                    _pixelBuffer.Set((PixelBufferCoordinate)h,
+                        (Pixel pixel, (byte pattern, Color consoleColor) mcC) => pixel.Blend(new Pixel(DrawingBoxSymbol.UpRightDownLeftFromPattern(
+                            mcC.pattern,
+                            lineStyle ?? LineStyle.SingleLine), mcC.consoleColor)),
+                        (pattern, consoleColor: color));
+                });
+                head = line.Vertical
+                    ? head.WithY(head.Y + 1)
+                    : head.WithX(head.X + 1);
             }
         }
 
@@ -378,43 +449,43 @@ namespace Consolonia.Core.Drawing
                 switch (c)
                 {
                     case '\t':
-                    {
-                        const int tabSize = 8;
-                        var consolePixel = new Pixel(' ', foregroundColor);
-                        for (int j = 0; j < tabSize; j++)
                         {
-                            Point newCharacterPoint = characterPoint.WithX(characterPoint.X + j);
-                            CurrentClip.ExecuteWithClipping(newCharacterPoint, () =>
+                            const int tabSize = 8;
+                            var consolePixel = new Pixel(' ', foregroundColor);
+                            for (int j = 0; j < tabSize; j++)
                             {
-                                _pixelBuffer.Set((PixelBufferCoordinate)newCharacterPoint,
-                                    (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);
-                            });
-                        }
+                                Point newCharacterPoint = characterPoint.WithX(characterPoint.X + j);
+                                CurrentClip.ExecuteWithClipping(newCharacterPoint, () =>
+                                {
+                                    _pixelBuffer.Set((PixelBufferCoordinate)newCharacterPoint,
+                                        (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);
+                                });
+                            }
 
-                        currentXPosition += tabSize - 1;
-                    }
+                            currentXPosition += tabSize - 1;
+                        }
                         break;
                     case '\n':
-                    {
-                        /* it's not clear if we need to draw anything. Cursor can be placed at the end of the line
-                         var consolePixel =  new Pixel(' ', foregroundColor);
+                        {
+                            /* it's not clear if we need to draw anything. Cursor can be placed at the end of the line
+                             var consolePixel =  new Pixel(' ', foregroundColor);
 
-                        _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
-                            (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);*/
-                    }
+                            _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
+                                (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);*/
+                        }
                         break;
                     case '\u200B':
                         currentXPosition--;
                         break;
                     default:
-                    {
-                        var consolePixel = new Pixel(c, foregroundColor, typeface.Style, typeface.Weight);
-                        CurrentClip.ExecuteWithClipping(characterPoint, () =>
                         {
-                            _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
-                                (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);
-                        });
-                    }
+                            var consolePixel = new Pixel(c, foregroundColor, typeface.Style, typeface.Weight);
+                            CurrentClip.ExecuteWithClipping(characterPoint, () =>
+                            {
+                                _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
+                                    (oldPixel, cp) => oldPixel.Blend(cp), consolePixel);
+                            });
+                        }
                         break;
                 }
             }

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -15,6 +15,13 @@ namespace Consolonia.Core.Drawing
 {
     internal class DrawingContextImpl : IDrawingContextImpl
     {
+        private const byte VerticalStartPattern = 0b0010;
+        private const byte VerticalLinePattern = 0b1010;
+        private const byte VerticalEndPattern = 0b1000;
+        private const byte HorizontalStartPattern = 0b0100;
+        private const byte HorizontalLinePattern = 0b0101;
+        private const byte HorizontalEndPattern = 0b0001;
+
         private readonly Stack<Rect> _clipStack = new(100);
         private readonly ConsoleWindow _consoleWindow;
         private readonly PixelBuffer _pixelBuffer;
@@ -296,13 +303,6 @@ namespace Consolonia.Core.Drawing
         /// </summary>
         /// <param name="pen">pen</param>
         /// <param name="line">line</param>
-        private const byte VERTICAL_START = 0b0010;
-        private const byte VERTICAL_LINE = 0b1010;
-        private const byte VERTICAL_END = 0b1000;
-        private const byte HORIZONTAL_START = 0b0100;
-        private const byte HORIZONTAL_LINE = 0b0101;
-        private const byte HORIZONTAL_END = 0b0001;
-
         private void DrawRectangleLineInternal(IPen pen, Line line)
         {
             if (pen.Thickness == 0) return;
@@ -320,13 +320,13 @@ namespace Consolonia.Core.Drawing
 
             var color = (Color)extractColorCheckPlatformSupported;
 
-            byte pattern = line.Vertical ? VERTICAL_START : HORIZONTAL_START;
+            byte pattern = line.Vertical ? VerticalStartPattern : HorizontalStartPattern;
             DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, 1); //beginning
 
-            pattern = line.Vertical ? VERTICAL_LINE : HORIZONTAL_LINE;
-            DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, line.Length - 1); //line
+            pattern = line.Vertical ? VerticalLinePattern : HorizontalLinePattern;
+            DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, line.Length - 2); //line
 
-            pattern = line.Vertical ? VERTICAL_END : HORIZONTAL_END;
+            pattern = line.Vertical ? VerticalEndPattern : HorizontalEndPattern;
             DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, 1); //ending 
         }
 

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -346,7 +346,7 @@ namespace Consolonia.Core.Drawing
         {
             if (pen.Brush is not MoveConsoleCaretToPositionBrush)
                 return false;
-                
+
             CurrentClip.ExecuteWithClipping(head,
                 () => { _pixelBuffer.Set((PixelBufferCoordinate)head, pixel => pixel.Blend(new Pixel(true))); });
             return true;

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -296,6 +296,13 @@ namespace Consolonia.Core.Drawing
         /// </summary>
         /// <param name="pen">pen</param>
         /// <param name="line">line</param>
+        private const byte VERTICAL_START = 0b0010;
+        private const byte VERTICAL_LINE = 0b1010;
+        private const byte VERTICAL_END = 0b1000;
+        private const byte HORIZONTAL_START = 0b0100;
+        private const byte HORIZONTAL_LINE = 0b0101;
+        private const byte HORIZONTAL_END = 0b0001;
+
         private void DrawRectangleLineInternal(IPen pen, Line line)
         {
             if (pen.Thickness == 0) return;
@@ -313,13 +320,13 @@ namespace Consolonia.Core.Drawing
 
             var color = (Color)extractColorCheckPlatformSupported;
 
-            byte pattern = (byte)(line.Vertical ? 0b0010 : 0b0100);
+            byte pattern = line.Vertical ? VERTICAL_START : HORIZONTAL_START;
             DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, 1); //beginning
 
-            pattern = (byte)(line.Vertical ? 0b1010 : 0b0101);
+            pattern = line.Vertical ? VERTICAL_LINE : HORIZONTAL_LINE;
             DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, line.Length - 1); //line
 
-            pattern = (byte)(line.Vertical ? 0b1000 : 0b0001);
+            pattern = line.Vertical ? VERTICAL_END : HORIZONTAL_END;
             DrawPixelAndMoveHead(ref head, line, lineStyle, pattern, color, 1); //ending 
         }
 

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -381,12 +381,12 @@ namespace Consolonia.Core.Drawing
             if (pen.Brush is LineBrush lineBrush)
                 lineStyle = lineBrush.LineStyle;
 
-            ConsoleBrush consoleColorBrush = ConsoleBrush.FromBrush(pen.Brush);
+            ConsoleBrush consoleBrush = ConsoleBrush.FromBrush(pen.Brush);
 
-            switch (consoleColorBrush.Mode)
+            switch (consoleBrush.Mode)
             {
                 case PixelBackgroundMode.Colored:
-                    return consoleColorBrush.Color;
+                    return consoleBrush.Color;
                 case PixelBackgroundMode.Transparent:
                     return null;
                 case PixelBackgroundMode.Shaded:
@@ -415,7 +415,7 @@ namespace Consolonia.Core.Drawing
                 {
                     // ReSharper disable once AccessToModifiedClosure todo: pass as a parameter
                     _pixelBuffer.Set((PixelBufferCoordinate)h,
-                        (Pixel pixel, (byte pattern, Color consoleColor) mcC) => pixel.Blend(new Pixel(DrawingBoxSymbol.UpRightDownLeftFromPattern(
+                        (pixel, mcC) => pixel.Blend(new Pixel(DrawingBoxSymbol.UpRightDownLeftFromPattern(
                             mcC.pattern,
                             lineStyle ?? LineStyle.SingleLine), mcC.consoleColor)),
                         (pattern, consoleColor: color));
@@ -429,7 +429,7 @@ namespace Consolonia.Core.Drawing
         private void DrawStringInternal(IBrush foreground, string str, IGlyphTypeface typeface, Point origin = new())
         {
             foreground = ConsoleBrush.FromBrush(foreground);
-            if (foreground is not ConsoleBrush { Mode: PixelBackgroundMode.Colored } consoleColorBrush)
+            if (foreground is not ConsoleBrush { Mode: PixelBackgroundMode.Colored } consoleBrush)
             {
                 ConsoloniaPlatform.RaiseNotSupported(4);
                 return;
@@ -444,7 +444,7 @@ namespace Consolonia.Core.Drawing
             foreach (char c in str)
             {
                 Point characterPoint = whereToDraw.Transform(Matrix.CreateTranslation(currentXPosition++, 0));
-                Color foregroundColor = consoleColorBrush.Color;
+                Color foregroundColor = consoleBrush.Color;
 
                 switch (c)
                 {

--- a/src/Consolonia.Core/Infrastructure/InputLessDefaultNetConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/InputLessDefaultNetConsole.cs
@@ -71,7 +71,7 @@ namespace Consolonia.Core.Infrastructure
             PauseTask?.Wait();
             SetCaretPosition(bufferPoint);
 
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             if (HasTextDecoration(textDecorations, TextDecorationLocation.Underline))
                 sb.Append(ConsoleUtils.Underline);
 
@@ -85,7 +85,8 @@ namespace Consolonia.Core.Infrastructure
 
             sb.Append(ConsoleUtils.Foreground(weight switch
             {
-                FontWeight.Medium or FontWeight.SemiBold or FontWeight.Bold or FontWeight.ExtraBold or FontWeight.Black or FontWeight.ExtraBlack
+                FontWeight.Medium or FontWeight.SemiBold or FontWeight.Bold or FontWeight.ExtraBold or FontWeight.Black
+                    or FontWeight.ExtraBlack
                     => foreground.Brighten(background),
                 FontWeight.Thin or FontWeight.ExtraLight or FontWeight.Light
                     => foreground.Shade(background),
@@ -101,11 +102,6 @@ namespace Consolonia.Core.Infrastructure
                 _headBufferPoint =
                     new PixelBufferCoordinate((ushort)(_headBufferPoint.X + str.Length), _headBufferPoint.Y);
             else _headBufferPoint = (PixelBufferCoordinate)((ushort)0, (ushort)(_headBufferPoint.Y + 1));
-        }
-
-        private static bool HasTextDecoration(TextDecorationCollection textDecorations, TextDecorationLocation location)
-        {
-            return textDecorations?.Any(td => td.Location == location) ?? false;
         }
 
         public event Action Resized;
@@ -130,6 +126,11 @@ namespace Consolonia.Core.Infrastructure
             // this is hack, but somehow it does not work when just calling ActualizeSize with same size
             Size = new PixelBufferSize(1, 1);
             Resized?.Invoke();
+        }
+
+        private static bool HasTextDecoration(TextDecorationCollection textDecorations, TextDecorationLocation location)
+        {
+            return textDecorations?.Any(td => td.Location == location) ?? false;
         }
 
         // ReSharper disable once MemberCanBePrivate.Global

--- a/src/Consolonia.Core/Infrastructure/InputLessDefaultNetConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/InputLessDefaultNetConsole.cs
@@ -8,7 +8,6 @@ using Avalonia.Input.Raw;
 using Avalonia.Media;
 using Consolonia.Core.Drawing.PixelBufferImplementation;
 using Consolonia.Core.Text;
-using NullLib.ConsoleEx;
 
 namespace Consolonia.Core.Infrastructure
 {
@@ -75,7 +74,7 @@ namespace Consolonia.Core.Infrastructure
             StringBuilder sb = new StringBuilder();
             if (textDecorations != null && textDecorations.Any(td => td.Location == TextDecorationLocation.Underline))
                 sb.Append(ConsoleUtils.Underline);
-            
+
             if (textDecorations != null && textDecorations.Any(td => td.Location == TextDecorationLocation.Strikethrough))
                 sb.Append(ConsoleUtils.Strikethrough);
 
@@ -83,16 +82,19 @@ namespace Consolonia.Core.Infrastructure
                 sb.Append(ConsoleUtils.Italic);
 
             sb.Append(ConsoleUtils.Background(background));
-            if (weight == FontWeight.Normal)
-                sb.Append(ConsoleUtils.Foreground(foreground));
-            else if (weight == FontWeight.Thin || weight == FontWeight.ExtraLight || weight == FontWeight.Light)
-                sb.Append(ConsoleUtils.Foreground(foreground.Shade(background)));
-            else if (weight == FontWeight.Medium || weight == FontWeight.SemiBold || weight == FontWeight.Bold ||
-                     weight == FontWeight.ExtraBold || weight == FontWeight.Black || weight == FontWeight.ExtraBlack)
-                sb.Append(ConsoleUtils.Foreground(foreground.Brighten(background)));
+            
+            sb.Append(ConsoleUtils.Foreground(weight switch
+            {
+                FontWeight.Medium or FontWeight.SemiBold or FontWeight.Bold or FontWeight.ExtraBold or FontWeight.Black or FontWeight.ExtraBlack 
+                    => foreground.Brighten(background),
+                FontWeight.Thin or FontWeight.ExtraLight or FontWeight.Light 
+                    => foreground.Shade(background),
+                _ => foreground
+            }));
+
             sb.Append(str);
             sb.Append(ConsoleUtils.Reset);
-            
+
             Console.Write(sb.ToString());
 
             if (_headBufferPoint.X < Size.Width - str.Length)

--- a/src/Consolonia.Core/Infrastructure/InputLessDefaultNetConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/InputLessDefaultNetConsole.cs
@@ -72,22 +72,22 @@ namespace Consolonia.Core.Infrastructure
             SetCaretPosition(bufferPoint);
 
             StringBuilder sb = new StringBuilder();
-            if (textDecorations != null && textDecorations.Any(td => td.Location == TextDecorationLocation.Underline))
+            if (HasTextDecoration(textDecorations, TextDecorationLocation.Underline))
                 sb.Append(ConsoleUtils.Underline);
 
-            if (textDecorations != null && textDecorations.Any(td => td.Location == TextDecorationLocation.Strikethrough))
+            if (HasTextDecoration(textDecorations, TextDecorationLocation.Strikethrough))
                 sb.Append(ConsoleUtils.Strikethrough);
 
             if (style == FontStyle.Italic)
                 sb.Append(ConsoleUtils.Italic);
 
             sb.Append(ConsoleUtils.Background(background));
-            
+
             sb.Append(ConsoleUtils.Foreground(weight switch
             {
-                FontWeight.Medium or FontWeight.SemiBold or FontWeight.Bold or FontWeight.ExtraBold or FontWeight.Black or FontWeight.ExtraBlack 
+                FontWeight.Medium or FontWeight.SemiBold or FontWeight.Bold or FontWeight.ExtraBold or FontWeight.Black or FontWeight.ExtraBlack
                     => foreground.Brighten(background),
-                FontWeight.Thin or FontWeight.ExtraLight or FontWeight.Light 
+                FontWeight.Thin or FontWeight.ExtraLight or FontWeight.Light
                     => foreground.Shade(background),
                 _ => foreground
             }));
@@ -101,6 +101,11 @@ namespace Consolonia.Core.Infrastructure
                 _headBufferPoint =
                     new PixelBufferCoordinate((ushort)(_headBufferPoint.X + str.Length), _headBufferPoint.Y);
             else _headBufferPoint = (PixelBufferCoordinate)((ushort)0, (ushort)(_headBufferPoint.Y + 1));
+        }
+
+        private static bool HasTextDecoration(TextDecorationCollection textDecorations, TextDecorationLocation location)
+        {
+            return textDecorations?.Any(td => td.Location == location) ?? false;
         }
 
         public event Action Resized;

--- a/src/Consolonia.Core/Text/ConsoleUtils.cs
+++ b/src/Consolonia.Core/Text/ConsoleUtils.cs
@@ -1,0 +1,36 @@
+using Avalonia.Media;
+
+namespace Consolonia.Core.Text
+{
+    /// <summary>
+    /// ANSI escape definitions and utility methods.
+    /// </summary>
+    internal static class ConsoleUtils
+    {
+        public const string Normal = $"\u001b[22m";
+        
+        public const string Bold = $"\u001b[1m";
+        
+        public const string Dim = $"\u001b[2m";
+        
+        public const string Italic = $"\u001b[3m";
+        
+        public const string Underline = $"\u001b[4m";
+        
+        public const string Strikethrough = $"\u001b[9m";
+
+        public const string Reset = "\u001b[0m";
+
+        public static string Foreground(Color color)
+            => Foreground(color.R, color.G, color.B);
+
+        public static string Foreground(byte red, byte green, byte blue)
+            => $"\u001b[38;2;{red};{green};{blue}m";
+
+        public static string Background(Color color)
+            => Background(color.R, color.G, color.B);
+
+        public static string Background(byte red, byte green, byte blue)
+            => $"\u001b[48;2;{red};{green};{blue}m";
+    }
+}

--- a/src/Consolonia.Core/Text/ConsoleUtils.cs
+++ b/src/Consolonia.Core/Text/ConsoleUtils.cs
@@ -3,7 +3,7 @@ using Avalonia.Media;
 namespace Consolonia.Core.Text
 {
     /// <summary>
-    /// ANSI escape definitions and utility methods.
+    ///     ANSI escape definitions and utility methods.
     /// </summary>
     internal static class ConsoleUtils
     {
@@ -19,15 +19,23 @@ namespace Consolonia.Core.Text
         public const string Strikethrough = "\u001b[9m";
 
         public static string Foreground(Color color)
-            => Foreground(color.R, color.G, color.B);
+        {
+            return Foreground(color.R, color.G, color.B);
+        }
 
         public static string Foreground(byte red, byte green, byte blue)
-            => $"\u001b[38;2;{red};{green};{blue}m";
+        {
+            return $"\u001b[38;2;{red};{green};{blue}m";
+        }
 
         public static string Background(Color color)
-            => Background(color.R, color.G, color.B);
+        {
+            return Background(color.R, color.G, color.B);
+        }
 
         public static string Background(byte red, byte green, byte blue)
-            => $"\u001b[48;2;{red};{green};{blue}m";
+        {
+            return $"\u001b[48;2;{red};{green};{blue}m";
+        }
     }
 }

--- a/src/Consolonia.Core/Text/ConsoleUtils.cs
+++ b/src/Consolonia.Core/Text/ConsoleUtils.cs
@@ -7,19 +7,16 @@ namespace Consolonia.Core.Text
     /// </summary>
     internal static class ConsoleUtils
     {
-        public const string Normal = $"\u001b[22m";
-        
-        public const string Bold = $"\u001b[1m";
-        
-        public const string Dim = $"\u001b[2m";
-        
-        public const string Italic = $"\u001b[3m";
-        
-        public const string Underline = $"\u001b[4m";
-        
-        public const string Strikethrough = $"\u001b[9m";
-
+        // style modifiers
         public const string Reset = "\u001b[0m";
+        public const string Normal = "\u001b[22m";
+        public const string Bold = "\u001b[1m";
+        public const string Dim = "\u001b[2m";
+
+        // text decorations
+        public const string Italic = "\u001b[3m";
+        public const string Underline = "\u001b[4m";
+        public const string Strikethrough = "\u001b[9m";
 
         public static string Foreground(Color color)
             => Foreground(color.R, color.G, color.B);

--- a/src/Consolonia.Core/Text/GlyphTypeface.cs
+++ b/src/Consolonia.Core/Text/GlyphTypeface.cs
@@ -76,8 +76,8 @@ namespace Consolonia.Core.Text
             UnderlinePosition =
                 -1, // this turns on TextDecorations="Underline", -1 is so it draws over the top of the text.
             UnderlineThickness = 1, // this is the thickness of the underline, aka 1 char thick.
-            StrikethroughPosition = 0,
-            StrikethroughThickness = 0,
+            StrikethroughPosition = -1,
+            StrikethroughThickness = 1,
             IsFixedPitch = true
         };
 

--- a/src/Consolonia.Gallery/Consolonia.Gallery.csproj
+++ b/src/Consolonia.Gallery/Consolonia.Gallery.csproj
@@ -22,17 +22,5 @@
       <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
     </ItemGroup>
 
-    <ItemGroup>
-      <AvaloniaXaml Update="Gallery\GalleryViews\GalleryGradientBrush.axaml">
-        <Generator>MSBuild:Compile</Generator>
-      </AvaloniaXaml>
-    </ItemGroup>
-
-    <ItemGroup>
-      <Compile Update="Gallery\GalleryViews\GalleryGradientBrush.xaml.cs">
-        <SubType>Code</SubType>
-        <DependentUpon>GalleryGradientBrush.axaml</DependentUpon>
-      </Compile>
-    </ItemGroup>
 
 </Project>

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryCanvas.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryCanvas.axaml
@@ -1,0 +1,38 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:drawing="clr-namespace:Consolonia.Core.Drawing;assembly=Consolonia.Core"
+             x:Class="Consolonia.Gallery.Gallery.GalleryViews.GalleryCanvas">
+    <Grid RowDefinitions="Auto Auto *">
+
+        <StackPanel>
+            <TextBlock TextDecorations="Underline">Canvas supports horizontal/vertical lines and rectangles</TextBlock>
+            <TextBlock>Lines</TextBlock>
+            <Grid RowDefinitions="Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto " ColumnDefinitions="Auto Auto ">
+                <TextBlock Grid.Column="1" Foreground="Black">0123456789</TextBlock>
+                <TextBlock Grid.Row="1" Foreground="Black">0</TextBlock>
+                <TextBlock Grid.Row="2" Foreground="Black">1</TextBlock>
+                <TextBlock Grid.Row="3" Foreground="Black">2</TextBlock>
+                <TextBlock Grid.Row="4" Foreground="Black">3</TextBlock>
+                <TextBlock Grid.Row="5" Foreground="Black">4</TextBlock>
+                <TextBlock Grid.Row="6" Foreground="Black">5</TextBlock>
+                <TextBlock Grid.Row="7" Foreground="Black">6</TextBlock>
+                <TextBlock Grid.Row="8" Foreground="Black">7</TextBlock>
+                <TextBlock Grid.Row="9" Foreground="Black">8</TextBlock>
+                <TextBlock Grid.Row="10" Foreground="Black">9</TextBlock>
+                <Canvas Background="DarkGreen" Grid.Row="1" Grid.Column="1" Grid.RowSpan="10" Width="10" Height="10" HorizontalAlignment="Left" >
+                    <Line StartPoint="1,0" EndPoint="2,0" Stroke="Yellow" StrokeThickness="1"/>
+                    <Line StartPoint="0,1" EndPoint="0,2" Stroke="Yellow" StrokeThickness="1"/>
+                    <Line StartPoint="0,9" EndPoint="10,9" Stroke="White" StrokeThickness="1"/>
+                    <Line StartPoint="9,0" EndPoint="9,10" Stroke="White" StrokeThickness="1"/>
+                </Canvas>
+            </Grid>
+        </StackPanel>
+        <TextBlock Grid.Row="1">Rectangles</TextBlock>
+        <Canvas Grid.Row="2" Background="AliceBlue" ClipToBounds="True">
+            <Rectangle Fill="Red" Height="5" Width="10" />
+            <Rectangle Fill="Blue" Height="5" Width="10" Canvas.Left="5" Canvas.Top="2"/>
+            <Rectangle Fill="Green" Height="5" Width="10" Canvas.Left="6" Margin="4" Canvas.Top="4"/>
+            <Rectangle Fill="Orange" Height="3" Width="5" Canvas.Right="4" Canvas.Bottom="4"/>
+        </Canvas>
+    </Grid>
+</UserControl>

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryCanvas.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryCanvas.axaml
@@ -22,6 +22,12 @@
                 <Canvas Background="DarkGreen" Grid.Row="1" Grid.Column="1" Grid.RowSpan="10" Width="10" Height="10" HorizontalAlignment="Left" >
                     <Line StartPoint="1,0" EndPoint="2,0" Stroke="Yellow" StrokeThickness="1"/>
                     <Line StartPoint="0,1" EndPoint="0,2" Stroke="Yellow" StrokeThickness="1"/>
+                    <Line StartPoint="4,4" EndPoint="8,8">
+                        <Line.Stroke>
+                            <drawing:LineBrush LineStyle="DoubleLine" Brush="Red"/>
+                        </Line.Stroke>
+                    </Line>
+
                     <Line StartPoint="0,9" EndPoint="10,9" Stroke="White" StrokeThickness="1"/>
                     <Line StartPoint="9,0" EndPoint="9,10" Stroke="White" StrokeThickness="1"/>
                 </Canvas>

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryCanvas.axaml.cs
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryCanvas.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Consolonia.Gallery.Gallery.GalleryViews
+{
+    [GalleryOrder(30)]
+    public partial class GalleryCanvas : UserControl
+    {
+        public GalleryCanvas()
+        {
+            InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryCanvas.axaml.cs
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryCanvas.axaml.cs
@@ -3,7 +3,6 @@ using Avalonia.Markup.Xaml;
 
 namespace Consolonia.Gallery.Gallery.GalleryViews
 {
-    [GalleryOrder(30)]
     public partial class GalleryCanvas : UserControl
     {
         public GalleryCanvas()

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryColors.axaml.cs
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryColors.axaml.cs
@@ -8,7 +8,6 @@ using Consolonia.Core.Drawing;
 
 namespace Consolonia.Gallery.Gallery.GalleryViews
 {
-    [GalleryOrder(1000)]
     public partial class GalleryColors : UserControl
     {
         public GalleryColors()

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryGradientBrush.axaml.cs
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryGradientBrush.axaml.cs
@@ -1,15 +1,10 @@
-using System;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
-using Consolonia.Core.Drawing;
 
 namespace Consolonia.Gallery.Gallery.GalleryViews
 {
-    [GalleryOrder(1000)]
     public partial class GalleryGradientBrush : UserControl
     {
         public GalleryGradientBrush()

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryImage.axaml.cs
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryImage.axaml.cs
@@ -1,10 +1,8 @@
-using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Consolonia.Gallery.Gallery.GalleryViews
 {
-    [GalleryOrder(1000)]
     public partial class GalleryImage : UserControl
     {
         public GalleryImage()

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryTextBlock.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryTextBlock.axaml
@@ -12,7 +12,7 @@
     <StackPanel Orientation="Vertical">
         <TextBlock Text="This is TextBlock" />
         <TextBlock Text="This is colored TextBlock" FontWeight="Bold" Background="DarkMagenta" Foreground="Chartreuse"/>
-        
+
         <StackPanel Orientation="Vertical" Margin="0" Background="DarkGray">
             <TextBlock TextTrimming="CharacterEllipsis"
                        Text="Text trimming with character ellipsis. Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
@@ -30,7 +30,11 @@
                    Text="Multiline TextBlock with TextWrapping.&#xD;&#xD;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est." />
         <TextBlock TextWrapping="Wrap"
                    Text="Special characters: Élève naïve: “𝔉𝔞𝔫𝔠𝔶” ligatures like ﬀ, ﬁ, and ﬂ; numbers ½, ¼; symbols like @, #, and €; emoji 😊; and math symbols Ω, ∑, √…"/>
-        <TextBlock Text="TextDecoration=Underline" TextDecorations="Underline" HorizontalAlignment="Left"/>
+        <StackPanel Orientation="Horizontal">
+            <TextBlock Text="TextDecoration=Underline" TextDecorations="Underline" HorizontalAlignment="Left"/>
+            <TextBlock Text="TextDecoration=Strikethrough" HorizontalAlignment="Left" TextDecorations="Strikethrough" />
+            <TextBlock Text="FontStyle=Italic" FontStyle="Italic" HorizontalAlignment="Left"/>
+        </StackPanel>
         <StackPanel Orientation="Horizontal">
             <TextBlock Text="FontWeight=BOLD" FontWeight="Bold" Foreground="Sienna"/>
             <TextBlock Text="FontWeight=NORMAL" FontWeight="Normal" Foreground="Sienna"/>


### PR DESCRIPTION
* Added Italic support
* Turned on Strikethrough (although it renders as underline)
* Added Canvas gallery page
* Removed dependency on Crayon library

Bug Fixes
* Fix line draws 1 too many chars #132 

Changes:
* Remove dependency on Crayon library, as it didn't implement italics and added ConsoleUtils
* Use Italic escape to handle FontStyle=Italic
* Refactor DrawLineInternal into  DrawLineInternal and DrawRectangleLineInternal

Details:
The issue is that DrawLineInternal was written to draw rectangle borders and then simply reused as the DrawLine implementation. The original DrawLineInternal draws Corner + Line + Corner. This always ended up drawing 1 more than the desired line length, when reused for a simple line.

The solution was to refactor the code into
* DrawLineInternal
* DrawRectangleLineInternal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `GalleryCanvas` user control for enhanced graphical representation, including lines and rectangles.
	- Added text decoration demonstrations in `GalleryTextBlock`, showcasing underline, strikethrough, and italic styles.
	- New utility class `ConsoleUtils` for ANSI escape code definitions and text formatting.

- **Bug Fixes**
	- Improved text rendering logic in `InputLessDefaultNetConsole`, allowing for more flexible formatting.

- **Refactor**
	- Enhanced drawing functionality and error handling in `DrawingContextImpl`.
	- Updated strikethrough metrics in `GlyphTypeface`.

- **Chores**
	- Removed unused package reference for `Crayon`.
	- Removed metadata attributes from `GalleryColors`, `GalleryGradientBrush`, and `GalleryImage` classes.
	- Removed references to unused XAML and code files in the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->