### PR TITLE
Enable alternate screen buffer

### DIFF
--- a/src/Consolonia.Core/Infrastructure/ConsoloniaLifetime.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoloniaLifetime.cs
@@ -1,9 +1,7 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
-using Consolonia.Core.Text;
 
 namespace Consolonia.Core.Infrastructure
 {

--- a/src/Consolonia.Core/Infrastructure/ConsoloniaLifetime.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoloniaLifetime.cs
@@ -1,12 +1,29 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
+using Consolonia.Core.Text;
 
 namespace Consolonia.Core.Infrastructure
 {
     public class ConsoloniaLifetime : ClassicDesktopStyleApplicationLifetime
     {
+        public ConsoloniaLifetime()
+        {
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+            Console.Write(ConsoleUtils.EnableAlternateBuffer);
+#pragma warning restore CA1303 // Do not pass literals as localized parameters
+            Exit += ConsoloniaLifetime_Exit;
+        }
+
+        private void ConsoloniaLifetime_Exit(object sender, ControlledApplicationLifetimeExitEventArgs e)
+        {
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+            Console.Write(ConsoleUtils.DisableAlternateBuffer);
+#pragma warning restore CA1303 // Do not pass literals as localized parameters
+        }
+
         /// <summary>
         ///     returned task indicates that console is successfully paused
         /// </summary>
@@ -31,5 +48,7 @@ namespace Consolonia.Core.Infrastructure
 
             return Dispatcher.UIThread.InvokeAsync(() => { }).GetTask();
         }
+
+
     }
 }

--- a/src/Consolonia.Core/Infrastructure/ConsoloniaLifetime.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoloniaLifetime.cs
@@ -9,21 +9,6 @@ namespace Consolonia.Core.Infrastructure
 {
     public class ConsoloniaLifetime : ClassicDesktopStyleApplicationLifetime
     {
-        public ConsoloniaLifetime()
-        {
-#pragma warning disable CA1303 // Do not pass literals as localized parameters
-            Console.Write(ConsoleUtils.EnableAlternateBuffer);
-#pragma warning restore CA1303 // Do not pass literals as localized parameters
-            Exit += ConsoloniaLifetime_Exit;
-        }
-
-        private void ConsoloniaLifetime_Exit(object sender, ControlledApplicationLifetimeExitEventArgs e)
-        {
-#pragma warning disable CA1303 // Do not pass literals as localized parameters
-            Console.Write(ConsoleUtils.DisableAlternateBuffer);
-#pragma warning restore CA1303 // Do not pass literals as localized parameters
-        }
-
         /// <summary>
         ///     returned task indicates that console is successfully paused
         /// </summary>
@@ -48,7 +33,5 @@ namespace Consolonia.Core.Infrastructure
 
             return Dispatcher.UIThread.InvokeAsync(() => { }).GetTask();
         }
-
-
     }
 }

--- a/src/Consolonia.Core/Infrastructure/InputLessDefaultNetConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/InputLessDefaultNetConsole.cs
@@ -118,7 +118,9 @@ namespace Consolonia.Core.Infrastructure
             PauseTask = task;
         }
 
+#pragma warning disable CA1063 // Implement IDisposable Correctly
         public void Dispose()
+#pragma warning restore CA1063 // Implement IDisposable Correctly
         {
             Dispose(true);
             GC.SuppressFinalize(this);

--- a/src/Consolonia.Core/Infrastructure/InputLessDefaultNetConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/InputLessDefaultNetConsole.cs
@@ -18,6 +18,9 @@ namespace Consolonia.Core.Infrastructure
 
         protected InputLessDefaultNetConsole()
         {
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+            Console.Write(ConsoleUtils.EnableAlternateBuffer);
+#pragma warning restore CA1303 // Do not pass literals as localized parameters
             Console.CursorVisible = false;
             ActualizeSize();
         }
@@ -119,6 +122,9 @@ namespace Consolonia.Core.Infrastructure
         {
             Dispose(true);
             GC.SuppressFinalize(this);
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+            Console.Write(ConsoleUtils.DisableAlternateBuffer);
+#pragma warning restore CA1303 // Do not pass literals as localized parameters
         }
 
         public void ClearOutput()

--- a/src/Consolonia.Core/Text/ConsoleUtils.cs
+++ b/src/Consolonia.Core/Text/ConsoleUtils.cs
@@ -18,6 +18,10 @@ namespace Consolonia.Core.Text
         public const string Underline = "\u001b[4m";
         public const string Strikethrough = "\u001b[9m";
 
+        // screen buffer
+        public const string EnableAlternateBuffer = "\u001b[?1049h";
+        public const string DisableAlternateBuffer = "\u001b[?1049l";
+
         public static string Foreground(Color color)
         {
             return Foreground(color.R, color.G, color.B);

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml
@@ -7,15 +7,17 @@
         <gallery:GalleryItemConverter x:Key="GalleryItemConverter" />
     </Window.Resources>
     <DockPanel>
-        <DataGrid x:Name="Grid"
-                  SelectedIndex="0"
-                  SelectionMode="Single"
-                  DockPanel.Dock="Left">
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="Name"
-                                    Binding="{Binding Name}" />
-            </DataGrid.Columns>
-        </DataGrid>
+        <Grid RowDefinitions="* Auto" DockPanel.Dock="Left">
+            <DataGrid x:Name="Grid"
+                      SelectedIndex="0"
+                      SelectionMode="Single">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Name"
+                                        Binding="{Binding Name}" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <Button Grid.Row="1" Content="Exit" Click="Exit_Click"/>
+        </Grid>
         <Border Child="{Binding ElementName=Grid,Path=SelectedItem, Converter={StaticResource GalleryItemConverter}}"
                 BorderThickness="1"
                 BorderBrush="{DynamicResource ThemeBorderBrush}" />

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml
@@ -16,7 +16,7 @@
                                         Binding="{Binding Name}" />
                 </DataGrid.Columns>
             </DataGrid>
-            <Button Grid.Row="1" Content="Exit" Click="Exit_Click"/>
+            <Button Grid.Row="1" Content="Exit" Click="Exit_Click" KeyboardNavigation.IsTabStop="False"/>
         </Grid>
         <Border Child="{Binding ElementName=Grid,Path=SelectedItem, Converter={StaticResource GalleryItemConverter}}"
                 BorderThickness="1"

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
@@ -68,5 +68,10 @@ namespace Consolonia.Gallery.View
             _commandLineArgs = args;
             TrySetupSelected();
         }
+
+        private void Exit_Click(object sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            this.Close();
+        }
     }
 }


### PR DESCRIPTION
* it restores the state of the screen entact when exiting
* This also gets rid of scrollbar indicator while consolonia app is running.

Changes:
* added escape codes to enable/disable secondary screen buffer
* Changed ConsoloniaLifetime to enable/disable
* Changed gallery app to have an EXIT button
![restore](https://github.com/user-attachments/assets/226b38dc-d982-4905-87c9-ccf493a9f815)

> NOTE: Adding the exit button uncovered a bug on ubuntu which is there before these changes #140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added functionality to enable and disable alternate console buffers for improved screen management.
	- Introduced an exit button in the `ControlsListView` for easier application closure.

- **Bug Fixes**
	- Improved lifecycle management of the console application during startup and exit.

- **Refactor**
	- Updated layout of the `ControlsListView` for better structure and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->