### PR TITLE
add support for NUGET publishing actions

### DIFF
--- a/.github/workflows/PublishIncrementalNuget.yml
+++ b/.github/workflows/PublishIncrementalNuget.yml
@@ -1,0 +1,49 @@
+name: Publish Incremental Nuget Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v4
+  
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+  
+      - name: Bump build version
+        id: bump
+        uses: vers-one/dotnet-project-version-updater@v1.5
+        with:
+          files: |
+            "**/Consolonia.csproj"
+          version: bump-build
+  
+      - name: Restore dependencies
+        run: dotnet restore source/Consolonia.sln
+
+      - name: Build
+        run: dotnet build source/Consolonia.sln -c Release --no-restore 
+  
+      - name: dotnet pack 
+        run: |
+          dotnet pack --no-build source/Consolonia.sln -c Release -o packages --include-symbols --property WarningLevel=0
+
+      - name: Publish NuGet and symbols
+        id: nuget-push
+        uses: edumserrano/nuget-push@v1
+        with:
+          api-key: '${{ secrets.NUGET_KEY }}' 
+          working-directory: 'packages'
+          fail-if-exists: false
+        
+      - name: Commit new version changes
+        run: |
+          git config --global user.name "Github Action"
+          git config --global user.email "jinek@users.noreply.github.com"
+          git commit -a -m "Bumped version for published nuget artifacts"
+          git push

--- a/.github/workflows/PublishNuget.yml
+++ b/.github/workflows/PublishNuget.yml
@@ -1,0 +1,35 @@
+name: Publish Nuget Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v4
+  
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+  
+      - name: Restore dependencies
+        run: dotnet restore source/Consolonia.sln
+
+      - name: Build
+        run: dotnet build source/Consolonia.sln -c Release --no-restore 
+  
+      - name: dotnet pack 
+        run: |
+          dotnet pack --no-build source/Consolonia.sln -c Release -o packages --include-symbols --property WarningLevel=0
+
+      - name: Publish NuGet and symbols
+        id: nuget-push
+        uses: edumserrano/nuget-push@v1
+        with:
+          api-key: '${{ secrets.NUGET_KEY }}' 
+          working-directory: 'packages'
+          fail-if-exists: false
+        


### PR DESCRIPTION
for #167 
 **PublishNuget**
- builds release and publishes nuget and symbol nuget for the current checked in version

 **PublishIncrementNuget**
- Bumps incremental build number (11.2.X)
- builds release and publishes nuget and symbol nuget for the
- Checks in updated build number

> NOTE: This needs a NUGET_KEY secret added