### PR TITLE
Fix dialog title

### DIFF
--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -159,7 +159,7 @@ namespace Consolonia.Core.Drawing
                     // if we have strokes to draw
                     if (streamGeometry.Strokes.Count > 0)
                     {
-                        pen = pen ?? new Pen(brush, 1);
+                        pen = pen ?? new Pen(brush);
 
                         var extractColorCheckPlatformSupported =
                             ExtractColorOrNullWithPlatformCheck(pen, out var lineStyle);

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -159,8 +159,7 @@ namespace Consolonia.Core.Drawing
                     // if we have strokes to draw
                     if (streamGeometry.Strokes.Count > 0)
                     {
-                        if (pen == null || pen.Thickness == 0)
-                            return;
+                        pen = pen ?? new Pen(brush, 1);
 
                         var extractColorCheckPlatformSupported =
                             ExtractColorOrNullWithPlatformCheck(pen, out var lineStyle);

--- a/src/Consolonia.Core/Text/Esc.cs
+++ b/src/Consolonia.Core/Text/Esc.cs
@@ -44,6 +44,14 @@ namespace Consolonia.Core.Text
         public const string EnableBracketedPasteMode = "\u001b[?2004h";
         public const string DisableBracktedPasteMode = "\u001b[?2004l";
 
+        // mouse tracking
+        public const string EnableMouseTracking = "\u001b[?1000h";
+        public const string DisableMouseTracking = "\u001b[?1000l";
+        public const string EnableMouseMotionTracking = "\u001b[?1002h";
+        public const string DisableMouseMotionTracking = "\u001b[?1002l";
+        public const string EnableExtendedMouseTracking = "\u001b[?1006h";
+        public const string DisableExtendedMouseTracking = "\u001b[?1006l";
+
         // move cursor
         public static string MoveCursorUp(int n)
         {

--- a/src/Consolonia.Themes/Templates/Controls/DialogWindow.axaml
+++ b/src/Consolonia.Themes/Templates/Controls/DialogWindow.axaml
@@ -43,20 +43,26 @@
                                HorizontalAlignment="Center"
                                VerticalAlignment="Center">
                             <Grid ColumnDefinitions="*">
-                                <Grid ColumnDefinitions="* Auto" VerticalAlignment="Top" Margin="1 0 0 0" ZIndex="30">
-                                    <StackPanel Orientation="Horizontal" >
+                                <Grid ColumnDefinitions="* Auto"
+                                      VerticalAlignment="Top"
+                                      Margin="1 0 0 0"
+                                      ZIndex="30">
+                                    <StackPanel Orientation="Horizontal">
                                         <helpers:SymbolsControl Text="{TemplateBinding Icon}"
                                                                 IsVisible="{Binding Icon.Length}"
                                                                 Foreground="{TemplateBinding BorderBrush}" />
-                                        <TextBlock Text="╡" Foreground="{TemplateBinding BorderBrush}" />
+                                        <TextBlock Text="╡"
+                                                   Foreground="{TemplateBinding BorderBrush}" />
                                         <TextBlock Text="{TemplateBinding Title}" />
-                                        <TextBlock Text="╞" Foreground="{TemplateBinding BorderBrush}" />
+                                        <TextBlock Text="╞"
+                                                   Foreground="{TemplateBinding BorderBrush}" />
                                     </StackPanel>
-                                    
+
                                     <StackPanel Grid.Column="1"
                                                 Orientation="Horizontal"
                                                 IsVisible="{TemplateBinding IsCloseButtonVisible}">
-                                        <Button Content="×" Margin="1 0 0 0"
+                                        <Button Content="×"
+                                                Margin="1 0 0 0"
                                                 Background="{x:Null}"
                                                 IsTabStop="False"
                                                 Padding="0"
@@ -71,7 +77,7 @@
                                     </StackPanel>
                                 </Grid>
 
-                                <Border BorderThickness="{TemplateBinding BorderThickness}" >
+                                <Border BorderThickness="{TemplateBinding BorderThickness}">
                                     <Border.BorderBrush>
                                         <controls:LineBrush
                                             Brush="{Binding Path=BorderBrush, RelativeSource={RelativeSource Mode=TemplatedParent}}"

--- a/src/Consolonia.Themes/Templates/Controls/DialogWindow.axaml
+++ b/src/Consolonia.Themes/Templates/Controls/DialogWindow.axaml
@@ -55,27 +55,25 @@
                                     IsHitTestVisible="False"
                                     Margin="{TemplateBinding Padding}" />
                             </Border>
-                            <StackPanel HorizontalAlignment="Left"
-                                        VerticalAlignment="Top"
-                                        Margin="{DynamicResource ConsoloniaDialogWindowBorderMargin}"
-                                        ZIndex="10"
-                                        Orientation="Horizontal">
-                                <helpers:SymbolsControl Text="{TemplateBinding Icon}"
-                                                        IsVisible="{Binding Icon.Length}"
-                                                        Foreground="{TemplateBinding BorderBrush}" />
-                                <TextBlock Text="{TemplateBinding Title}"
-                                           Margin="1 0 0 0" />
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal"
-                                        ZIndex="10"
-                                        VerticalAlignment="Top"
-                                        HorizontalAlignment="Right"
-                                        Margin="{DynamicResource ConsoloniaDialogWindowBorderMargin}"
-                                        IsVisible="{TemplateBinding IsCloseButtonVisible}">
-                                <Button Content="×"
+                            <!-- titlebar -->
+                            <Grid RowDefinitions="Auto" ColumnDefinitions="* Auto">
+                                <StackPanel HorizontalAlignment="Left"
+                                            VerticalAlignment="Top"
+                                            Margin="2 0 3 0"
+                                            ZIndex="10"
+                                            Orientation="Horizontal">
+                                    <helpers:SymbolsControl Text="{TemplateBinding Icon}"
+                                                            IsVisible="{Binding Icon.Length}"
+                                                            Foreground="{TemplateBinding BorderBrush}" />
+                                    <TextBlock Text="╡" Foreground="{TemplateBinding BorderBrush}" />
+                                    <TextBlock Text="{TemplateBinding Title}" Margin="0"/>
+                                    <TextBlock Text="╞" Foreground="{TemplateBinding BorderBrush}" />
+                                </StackPanel>
+                                <Button Content="×" IsVisible="{TemplateBinding IsCloseButtonVisible}"
                                         Background="{x:Null}"
                                         IsTabStop="False"
-                                        Padding="0"
+                                        Margin="0 0 1 0"
+                                        Padding="0" Grid.Column="1" 
                                         Command="{Binding Path=CloseClick, RelativeSource={RelativeSource TemplatedParent}}">
                                     <Button.Styles>
                                         <Style Selector="Button">
@@ -84,7 +82,7 @@
                                         </Style>
                                     </Button.Styles>
                                 </Button>
-                            </StackPanel>
+                            </Grid>
                         </Panel>
 
                         <!--Content-->

--- a/src/Consolonia.Themes/Templates/Controls/DialogWindow.axaml
+++ b/src/Consolonia.Themes/Templates/Controls/DialogWindow.axaml
@@ -42,46 +42,47 @@
                         <Panel Background="{TemplateBinding Background}"
                                HorizontalAlignment="Center"
                                VerticalAlignment="Center">
-                            <Border BorderThickness="{TemplateBinding BorderThickness}"
-                                    Margin="{DynamicResource ConsoloniaDialogWindowBorderMargin}">
-                                <Border.BorderBrush>
-                                    <controls:LineBrush
-                                        Brush="{Binding Path=BorderBrush, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                        LineStyle="DoubleLine" />
-                                </Border.BorderBrush>
-                                <Control
-                                    Width="{Binding Path=ContentSize.Width, RelativeSource={RelativeSource TemplatedParent}}"
-                                    Height="{Binding Path=ContentSize.Height, RelativeSource={RelativeSource TemplatedParent}}"
-                                    IsHitTestVisible="False"
-                                    Margin="{TemplateBinding Padding}" />
-                            </Border>
-                            <!-- titlebar -->
-                            <Grid RowDefinitions="Auto" ColumnDefinitions="* Auto">
-                                <StackPanel HorizontalAlignment="Left"
-                                            VerticalAlignment="Top"
-                                            Margin="2 0 3 0"
-                                            ZIndex="10"
-                                            Orientation="Horizontal">
-                                    <helpers:SymbolsControl Text="{TemplateBinding Icon}"
-                                                            IsVisible="{Binding Icon.Length}"
-                                                            Foreground="{TemplateBinding BorderBrush}" />
-                                    <TextBlock Text="╡" Foreground="{TemplateBinding BorderBrush}" />
-                                    <TextBlock Text="{TemplateBinding Title}" Margin="0"/>
-                                    <TextBlock Text="╞" Foreground="{TemplateBinding BorderBrush}" />
-                                </StackPanel>
-                                <Button Content="×" IsVisible="{TemplateBinding IsCloseButtonVisible}"
-                                        Background="{x:Null}"
-                                        IsTabStop="False"
-                                        Margin="0 0 1 0"
-                                        Padding="0" Grid.Column="1" 
-                                        Command="{Binding Path=CloseClick, RelativeSource={RelativeSource TemplatedParent}}">
-                                    <Button.Styles>
-                                        <Style Selector="Button">
-                                            <Setter Property="helpers:ButtonExtensions.Shadow"
-                                                    Value="False" />
-                                        </Style>
-                                    </Button.Styles>
-                                </Button>
+                            <Grid ColumnDefinitions="*">
+                                <Grid ColumnDefinitions="* Auto" VerticalAlignment="Top" Margin="1 0 0 0" ZIndex="30">
+                                    <StackPanel Orientation="Horizontal" >
+                                        <helpers:SymbolsControl Text="{TemplateBinding Icon}"
+                                                                IsVisible="{Binding Icon.Length}"
+                                                                Foreground="{TemplateBinding BorderBrush}" />
+                                        <TextBlock Text="╡" Foreground="{TemplateBinding BorderBrush}" />
+                                        <TextBlock Text="{TemplateBinding Title}" />
+                                        <TextBlock Text="╞" Foreground="{TemplateBinding BorderBrush}" />
+                                    </StackPanel>
+                                    
+                                    <StackPanel Grid.Column="1"
+                                                Orientation="Horizontal"
+                                                IsVisible="{TemplateBinding IsCloseButtonVisible}">
+                                        <Button Content="×" Margin="1 0 0 0"
+                                                Background="{x:Null}"
+                                                IsTabStop="False"
+                                                Padding="0"
+                                                Command="{Binding Path=CloseClick, RelativeSource={RelativeSource TemplatedParent}}">
+                                            <Button.Styles>
+                                                <Style Selector="Button">
+                                                    <Setter Property="helpers:ButtonExtensions.Shadow"
+                                                            Value="False" />
+                                                </Style>
+                                            </Button.Styles>
+                                        </Button>
+                                    </StackPanel>
+                                </Grid>
+
+                                <Border BorderThickness="{TemplateBinding BorderThickness}" >
+                                    <Border.BorderBrush>
+                                        <controls:LineBrush
+                                            Brush="{Binding Path=BorderBrush, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                            LineStyle="DoubleLine" />
+                                    </Border.BorderBrush>
+                                    <Control
+                                        Width="{Binding Path=ContentSize.Width, RelativeSource={RelativeSource TemplatedParent}}"
+                                        Height="{Binding Path=ContentSize.Height, RelativeSource={RelativeSource TemplatedParent}}"
+                                        IsHitTestVisible="False"
+                                        Margin="{TemplateBinding Padding}" />
+                                </Border>
                             </Grid>
                         </Panel>
 


### PR DESCRIPTION
* MessageBox shadow was broken
* Fixed title that overlapped close button
* Added a bit of turbovision pizazz to double line with ```==| text |===```
![image](https://github.com/user-attachments/assets/d6e9c55c-9d3d-4d14-b090-ab7393a28c07)
