### PR TITLE
bump version and fix patch pattern to correctly allow for numeric patch numbers

### DIFF
--- a/.github/workflows/general_build.yml
+++ b/.github/workflows/general_build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Test
         run: dotnet test # --configuration release todo: release get stuck and never finishes
       - name: Pack
-        run: dotnet pack --configuration release -o ./packages --version-suffix alpha-${{ github.run_number }} # https://stackoverflow.com/a/60067489/2362847
+        run: dotnet pack --configuration release -o ./packages --version-suffix beta.${{ github.run_number }} # https://stackoverflow.com/a/60067489/2362847
       - name: Push
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main'}}
         run: dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
         <Nullable>disable</Nullable>
     </PropertyGroup>
     <PropertyGroup>
-        <VersionPrefix>11.2.1</VersionPrefix>
+        <VersionPrefix>11.2.3</VersionPrefix>
         <Authors>https://github.com/jinek/Consolonia/graphs/contributors</Authors>
         <Description>Text User Interface implementation of Avalonia UI (GUI Framework)</Description>
         <Copyright>Copyright © Evgeny Gorbovoy 2021 - 2022</Copyright>
@@ -16,7 +16,7 @@
         <IsPackable>False</IsPackable>
     </PropertyGroup>
     <PropertyGroup>
-        <AvaloniaVersion>11.2.1</AvaloniaVersion>
+        <AvaloniaVersion>11.2.3</AvaloniaVersion>
     </PropertyGroup>
     <ItemGroup Condition="'$(IsPackable)' != 'false'">
         <None Include="$(SolutionDir)/../Icon.png" Pack="True" PackagePath="\" />

--- a/src/Tools/Consolonia.Templates/ConsoloniaAppTemplate/ConsoloniaAppTemplate.csproj
+++ b/src/Tools/Consolonia.Templates/ConsoloniaAppTemplate/ConsoloniaAppTemplate.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Consolonia" Version="11.2.3-beta" />
+        <PackageReference Include="Consolonia" Version="11.2.1-alpha" />
     </ItemGroup>
 
 </Project>

--- a/src/Tools/Consolonia.Templates/ConsoloniaAppTemplate/ConsoloniaAppTemplate.csproj
+++ b/src/Tools/Consolonia.Templates/ConsoloniaAppTemplate/ConsoloniaAppTemplate.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Consolonia" Version="11.2.1-alpha-748" />
+        <PackageReference Include="Consolonia" Version="11.2.3-beta" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Changes:
* Bump version of avalonia to 11.2.3
* Bump prerelease from -alpha to -beta 
* Change pattern to dot PATCH instead of dash PATCH

### Details
We aren't doing patch pattern right. 

We are doing a dash between -alpha and patch number and is text sorting
```11.2.1-alpha-20 > 11.2.1-alpha-100```
 
We should be doing dot PATCH like this:

```11.2.1-alpha.PATCH```

aka a '.' between alpha and PATCH number.  If we do it that way then the sorting will be 

```11.2.1-alpha.100 > 11.2.1-alpha.20```

If we change that then our template can have a dependency of 
```<package "Consolonia" Version="11.2.1-alpha"/>```

And it should take the newest version.