### PR TITLE
fix preview of TopLevel/Window classes

### DIFF
--- a/src/Tools/Consolonia.PreviewHost/ViewModels/XamlFileViewModel.cs
+++ b/src/Tools/Consolonia.PreviewHost/ViewModels/XamlFileViewModel.cs
@@ -74,6 +74,17 @@ namespace Consolonia.PreviewHost.ViewModels
 
 
                 object content = AvaloniaRuntimeXamlLoader.Load(xaml, Assembly, designMode: true);
+                if (content is TopLevel top)
+                {
+                    // If the root element is a TopLevel, we can't use it as the content of the panel
+                    if (top.Content != null)
+                    {
+                        // So we'll use the content of the TopLevel as the content of the panel
+                        content = top.Content;
+                        top.Content = null;
+                    }
+                }
+
                 if (content is Control control)
                 {
                     Application.Current!.TryGetResource("ThemeBorderBrush", null, out object? borderBrush);

--- a/src/Tools/Consolonia.PreviewHost/ViewModels/XamlFileViewModel.cs
+++ b/src/Tools/Consolonia.PreviewHost/ViewModels/XamlFileViewModel.cs
@@ -75,7 +75,6 @@ namespace Consolonia.PreviewHost.ViewModels
 
                 object content = AvaloniaRuntimeXamlLoader.Load(xaml, Assembly, designMode: true);
                 if (content is TopLevel top)
-                {
                     // If the root element is a TopLevel, we can't use it as the content of the panel
                     if (top.Content != null)
                     {
@@ -83,7 +82,6 @@ namespace Consolonia.PreviewHost.ViewModels
                         content = top.Content;
                         top.Content = null;
                     }
-                }
 
                 if (content is Control control)
                 {


### PR DESCRIPTION
If the .xaml file is a TopLevel (like a window) then it can't be the displayed as part of a subpanel directly.

This fix takes the contents of the TopLevel and displays it in the display panel