### PR TITLE
make sure console is restored 

### DIFF
--- a/src/Consolonia.Core/ConsoloniaLifetime.cs
+++ b/src/Consolonia.Core/ConsoloniaLifetime.cs
@@ -92,10 +92,19 @@ namespace Consolonia
 
             (TopLevel as Window)?.Show();
 
-            Dispatcher.UIThread.MainLoop(_cts.Token);
-            Environment.ExitCode = _exitCode;
-            return _exitCode;
-        } // ReSharper disable UnusedParameter.Local
+            try
+            {
+                Dispatcher.UIThread.MainLoop(_cts.Token);
+                Environment.ExitCode = _exitCode;
+                return _exitCode;
+            }
+            finally
+            {
+                Dispose();
+            }
+        }
+
+        // ReSharper disable UnusedParameter.Local
         // ReSharper disable UnusedMember.Local
 #pragma warning disable IDE0060 // Remove unused parameter
         private bool DoShutdown(
@@ -117,9 +126,6 @@ namespace Consolonia
 
             _exitCode = exitCode;
             _isShuttingDown = true;
-
-            var consoleWindow = (ConsoleWindow)TopLevel.PlatformImpl;
-            consoleWindow.Console.RestoreConsole();
 
             try
             {
@@ -192,6 +198,9 @@ namespace Consolonia
                     // TODO: dispose managed state (managed objects)
                     _cts?.Dispose();
                     _cts = null;
+                    var consoleWindow = TopLevel.PlatformImpl as ConsoleWindow;
+                    ArgumentNullException.ThrowIfNull(consoleWindow, nameof(consoleWindow));
+                    consoleWindow.Dispose();
                 }
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer

--- a/src/Consolonia.Core/ConsoloniaLifetime.cs
+++ b/src/Consolonia.Core/ConsoloniaLifetime.cs
@@ -102,9 +102,7 @@ namespace Consolonia
             {
                 Dispose();
             }
-        }
-
-        // ReSharper disable UnusedParameter.Local
+        } // ReSharper disable UnusedParameter.Local
         // ReSharper disable UnusedMember.Local
 #pragma warning disable IDE0060 // Remove unused parameter
         private bool DoShutdown(

--- a/src/Consolonia.PlatformSupport/CursesConsole.cs
+++ b/src/Consolonia.PlatformSupport/CursesConsole.cs
@@ -108,8 +108,9 @@ namespace Consolonia.PlatformSupport
                 (Curses.Event.ButtonWheeledUp, RawPointerEventType.Wheel)
             });
 
-        private KeyModifiers _keyModifiers;
         private Curses.Window _cursesWindow;
+
+        private KeyModifiers _keyModifiers;
 
         public CursesConsole()
             : base(new AnsiConsoleOutput())
@@ -244,200 +245,200 @@ namespace Consolonia.PlatformSupport
             {
                 // Special handling for ESC, we want to try to catch ESC+letter to simulate alt-letter as well as Alt-Fkey
                 case 27:
+                {
+                    Curses.timeout(200);
+
+                    code = Curses.get_wch(out int wch2);
+
+                    if (code == Curses.KEY_CODE_YES) k = Key.AltMask | MapCursesKey(wch);
+
+                    if (code == 0)
                     {
-                        Curses.timeout(200);
+                        //KeyEvent key;
 
-                        code = Curses.get_wch(out int wch2);
-
-                        if (code == Curses.KEY_CODE_YES) k = Key.AltMask | MapCursesKey(wch);
-
-                        if (code == 0)
-                        {
-                            //KeyEvent key;
-
-                            // The ESC-number handling, debatable.
-                            // Simulates the AltMask itself by pressing Alt + Space.
-                            if (wch2 == (int)Key.Space)
-                                k = Key.AltMask;
-                            else if (wch2 - (int)Key.Space >= (uint)Key.A && wch2 - (int)Key.Space <= (uint)Key.Z)
-                                k = (Key)((uint)Key.AltMask + (wch2 - (int)Key.Space));
-                            else if (wch2 >= (uint)Key.A - 64 && wch2 <= (uint)Key.Z - 64)
-                                k = (Key)((uint)(Key.AltMask | Key.CtrlMask) + (wch2 + 64));
-                            else if (wch2 >= (uint)Key.D0 && wch2 <= (uint)Key.D9)
-                                k = (Key)((uint)Key.AltMask + (uint)Key.D0 + (wch2 - (uint)Key.D0));
-                            else
-                                switch (wch2)
-                                {
-                                    case 27:
-                                        k = (Key)wch2;
-                                        break;
-                                    case Curses.KEY_CODE_SEQ:
-                                        {
-                                            int[] c = null;
-                                            while (code == 0)
-                                            {
-                                                code = Curses.get_wch(out wch2);
-                                                if (wch2 <= 0) continue;
-                                                int length = 1;
-                                                if (c != null)
-                                                    length += c.Length;
-                                                Array.Resize(ref c, length);
-
-                                                c[^1] = wch2;
-                                            }
-
-                                            switch (c![0])
-                                            {
-                                                case 49 when c[1] == 59 && c[2] == 55 && c[3] >= 80 && c[3] <= 83:
-                                                    // Ctrl+Alt+(F1 - F4)
-                                                    wch2 = c[3] + 185;
-                                                    k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
-                                                    break;
-                                                case 49
-                                                    when c[2] == 59 && c[3] == 55 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
-                                                    // Ctrl+Alt+(F5 - F8)
-                                                    wch2 = c[1] == 53 ? c[1] + 216 : c[1] + 215;
-                                                    k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
-                                                    break;
-                                                case 50
-                                                    when c[2] == 59 && c[3] == 55 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
-                                                    // Ctrl+Alt+(F9 - F12)
-                                                    wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
-                                                    k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
-                                                    break;
-                                                case 49 when c[1] == 59 && c[2] == 56 && c[3] >= 80 && c[3] <= 83:
-                                                    // Ctrl+Shift+Alt+(F1 - F4)
-                                                    wch2 = c[3] + 185;
-                                                    k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                                    break;
-                                                case 49
-                                                    when c[2] == 59 && c[3] == 56 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
-                                                    // Ctrl+Shift+Alt+(F5 - F8)
-                                                    wch2 = c[1] == 53 ? c[1] + 216 : c[1] + 215;
-                                                    k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                                    break;
-                                                case 50
-                                                    when c[2] == 59 && c[3] == 56 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
-                                                    // Ctrl+Shift+Alt+(F9 - F12)
-                                                    wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
-                                                    k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                                    break;
-                                                case 49 when c[1] == 59 && c[2] == 52 && c[3] == 83:
-                                                    // Shift+Alt+(F4)
-                                                    wch2 = 268;
-                                                    k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                                    break;
-                                                case 49
-                                                    when c[2] == 59 && c[3] == 52 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
-                                                    // Shift+Alt+(F5 - F8)
-                                                    wch2 = c[1] < 55 ? c[1] + 216 : c[1] + 215;
-                                                    k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                                    break;
-                                                case 50
-                                                    when c[2] == 59 && c[3] == 52 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
-                                                    // Shift+Alt+(F9 - F12)
-                                                    wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
-                                                    k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                                    break;
-                                                case 54 when c[1] == 59 && c[2] == 56 && c[3] == 126:
-                                                    // Shift+Ctrl+Alt+KeyNPage
-                                                    k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.PageDown;
-                                                    break;
-                                                case 53 when c[1] == 59 && c[2] == 56 && c[3] == 126:
-                                                    // Shift+Ctrl+Alt+KeyPPage
-                                                    k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.PageUp;
-                                                    break;
-                                                case 49 when c[1] == 59 && c[2] == 56 && c[3] == 72:
-                                                    // Shift+Ctrl+Alt+KeyHome
-                                                    k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.Home;
-                                                    break;
-                                                case 49 when c[1] == 59 && c[2] == 56 && c[3] == 70:
-                                                    // Shift+Ctrl+Alt+KeyEnd
-                                                    k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.End;
-                                                    break;
-
-                                                // ESC [200~ 
-                                                case 50 when c[1] == 48 && c[2] == 48 && c[3] == 126:
-                                                    var sb = new StringBuilder();
-                                                    for (int i = 4; i < c.Length; i++) sb.Append((char)c[i]);
-                                                    string bufferText = sb.ToString();
-                                                    int index = bufferText.IndexOf("\u001b[201~", StringComparison.Ordinal);
-                                                    if (index > 0)
-                                                    {
-                                                        string text = bufferText[..--index];
-                                                        await DispatchInputAsync(() =>
-                                                        {
-                                                            RaiseTextInput(text, (ulong)Stopwatch.GetTimestamp());
-                                                        });
-                                                    }
-
-                                                    break;
-
-                                                default:
-                                                    k = MapCursesKey(wch2);
-                                                    break;
-                                            }
-
-                                            break;
-                                        }
-                                    default:
-                                        {
-                                            // Unfortunately there are no way to differentiate Ctrl+Alt+alfa and Ctrl+Shift+Alt+alfa.
-                                            if (((Key)wch2 & Key.CtrlMask) != 0) _keyModifiers.Ctrl = true;
-
-                                            if (wch2 == 0)
-                                            {
-                                                k = Key.CtrlMask | Key.AltMask | Key.Space;
-                                            }
-                                            // ReSharper disable once ConditionIsAlwaysTrueOrFalse todo: check why
-                                            else if (wch >= (uint)Key.A && wch <= (uint)Key.Z)
-                                            {
-                                                _keyModifiers.Shift = true;
-                                                _keyModifiers.Alt = true;
-                                            }
-                                            else if (wch2 < 256)
-                                            {
-                                                k = (Key)wch2;
-                                                _keyModifiers.Alt = true;
-                                            }
-                                            else
-                                            {
-                                                k = (Key)((uint)(Key.AltMask | Key.CtrlMask) + wch2);
-                                            }
-
-                                            break;
-                                        }
-                                }
-                        }
+                        // The ESC-number handling, debatable.
+                        // Simulates the AltMask itself by pressing Alt + Space.
+                        if (wch2 == (int)Key.Space)
+                            k = Key.AltMask;
+                        else if (wch2 - (int)Key.Space >= (uint)Key.A && wch2 - (int)Key.Space <= (uint)Key.Z)
+                            k = (Key)((uint)Key.AltMask + (wch2 - (int)Key.Space));
+                        else if (wch2 >= (uint)Key.A - 64 && wch2 <= (uint)Key.Z - 64)
+                            k = (Key)((uint)(Key.AltMask | Key.CtrlMask) + (wch2 + 64));
+                        else if (wch2 >= (uint)Key.D0 && wch2 <= (uint)Key.D9)
+                            k = (Key)((uint)Key.AltMask + (uint)Key.D0 + (wch2 - (uint)Key.D0));
                         else
-                        {
-                            k = Key.Esc;
-                        }
+                            switch (wch2)
+                            {
+                                case 27:
+                                    k = (Key)wch2;
+                                    break;
+                                case Curses.KEY_CODE_SEQ:
+                                {
+                                    int[] c = null;
+                                    while (code == 0)
+                                    {
+                                        code = Curses.get_wch(out wch2);
+                                        if (wch2 <= 0) continue;
+                                        int length = 1;
+                                        if (c != null)
+                                            length += c.Length;
+                                        Array.Resize(ref c, length);
 
-                        break;
+                                        c[^1] = wch2;
+                                    }
+
+                                    switch (c![0])
+                                    {
+                                        case 49 when c[1] == 59 && c[2] == 55 && c[3] >= 80 && c[3] <= 83:
+                                            // Ctrl+Alt+(F1 - F4)
+                                            wch2 = c[3] + 185;
+                                            k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
+                                            break;
+                                        case 49
+                                            when c[2] == 59 && c[3] == 55 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
+                                            // Ctrl+Alt+(F5 - F8)
+                                            wch2 = c[1] == 53 ? c[1] + 216 : c[1] + 215;
+                                            k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
+                                            break;
+                                        case 50
+                                            when c[2] == 59 && c[3] == 55 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
+                                            // Ctrl+Alt+(F9 - F12)
+                                            wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
+                                            k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
+                                            break;
+                                        case 49 when c[1] == 59 && c[2] == 56 && c[3] >= 80 && c[3] <= 83:
+                                            // Ctrl+Shift+Alt+(F1 - F4)
+                                            wch2 = c[3] + 185;
+                                            k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                            break;
+                                        case 49
+                                            when c[2] == 59 && c[3] == 56 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
+                                            // Ctrl+Shift+Alt+(F5 - F8)
+                                            wch2 = c[1] == 53 ? c[1] + 216 : c[1] + 215;
+                                            k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                            break;
+                                        case 50
+                                            when c[2] == 59 && c[3] == 56 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
+                                            // Ctrl+Shift+Alt+(F9 - F12)
+                                            wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
+                                            k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                            break;
+                                        case 49 when c[1] == 59 && c[2] == 52 && c[3] == 83:
+                                            // Shift+Alt+(F4)
+                                            wch2 = 268;
+                                            k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                            break;
+                                        case 49
+                                            when c[2] == 59 && c[3] == 52 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
+                                            // Shift+Alt+(F5 - F8)
+                                            wch2 = c[1] < 55 ? c[1] + 216 : c[1] + 215;
+                                            k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                            break;
+                                        case 50
+                                            when c[2] == 59 && c[3] == 52 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
+                                            // Shift+Alt+(F9 - F12)
+                                            wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
+                                            k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                            break;
+                                        case 54 when c[1] == 59 && c[2] == 56 && c[3] == 126:
+                                            // Shift+Ctrl+Alt+KeyNPage
+                                            k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.PageDown;
+                                            break;
+                                        case 53 when c[1] == 59 && c[2] == 56 && c[3] == 126:
+                                            // Shift+Ctrl+Alt+KeyPPage
+                                            k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.PageUp;
+                                            break;
+                                        case 49 when c[1] == 59 && c[2] == 56 && c[3] == 72:
+                                            // Shift+Ctrl+Alt+KeyHome
+                                            k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.Home;
+                                            break;
+                                        case 49 when c[1] == 59 && c[2] == 56 && c[3] == 70:
+                                            // Shift+Ctrl+Alt+KeyEnd
+                                            k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.End;
+                                            break;
+
+                                        // ESC [200~ 
+                                        case 50 when c[1] == 48 && c[2] == 48 && c[3] == 126:
+                                            var sb = new StringBuilder();
+                                            for (int i = 4; i < c.Length; i++) sb.Append((char)c[i]);
+                                            string bufferText = sb.ToString();
+                                            int index = bufferText.IndexOf("\u001b[201~", StringComparison.Ordinal);
+                                            if (index > 0)
+                                            {
+                                                string text = bufferText[..--index];
+                                                await DispatchInputAsync(() =>
+                                                {
+                                                    RaiseTextInput(text, (ulong)Stopwatch.GetTimestamp());
+                                                });
+                                            }
+
+                                            break;
+
+                                        default:
+                                            k = MapCursesKey(wch2);
+                                            break;
+                                    }
+
+                                    break;
+                                }
+                                default:
+                                {
+                                    // Unfortunately there are no way to differentiate Ctrl+Alt+alfa and Ctrl+Shift+Alt+alfa.
+                                    if (((Key)wch2 & Key.CtrlMask) != 0) _keyModifiers.Ctrl = true;
+
+                                    if (wch2 == 0)
+                                    {
+                                        k = Key.CtrlMask | Key.AltMask | Key.Space;
+                                    }
+                                    // ReSharper disable once ConditionIsAlwaysTrueOrFalse todo: check why
+                                    else if (wch >= (uint)Key.A && wch <= (uint)Key.Z)
+                                    {
+                                        _keyModifiers.Shift = true;
+                                        _keyModifiers.Alt = true;
+                                    }
+                                    else if (wch2 < 256)
+                                    {
+                                        k = (Key)wch2;
+                                        _keyModifiers.Alt = true;
+                                    }
+                                    else
+                                    {
+                                        k = (Key)((uint)(Key.AltMask | Key.CtrlMask) + wch2);
+                                    }
+
+                                    break;
+                                }
+                            }
                     }
+                    else
+                    {
+                        k = Key.Esc;
+                    }
+
+                    break;
+                }
                 case Curses.KeyTab:
                     k = MapCursesKey(wch);
                     break;
                 default:
+                {
+                    // Unfortunately there are no way to differentiate Ctrl+alfa and Ctrl+Shift+alfa.
+                    k = (Key)wch;
+                    if (wch == 0)
                     {
-                        // Unfortunately there are no way to differentiate Ctrl+alfa and Ctrl+Shift+alfa.
-                        k = (Key)wch;
-                        if (wch == 0)
-                        {
-                            k = Key.CtrlMask | Key.Space;
-                        }
-                        else if (wch >= (uint)Key.A - 64 && wch <= (uint)Key.Z - 64)
-                        {
-                            if ((Key)(wch + 64) != Key.J) k = Key.CtrlMask | (Key)(wch + 64);
-                        }
-                        else if (wch >= (uint)Key.A && wch <= (uint)Key.Z)
-                        {
-                            _keyModifiers.Shift = true;
-                        }
-
-                        break;
+                        k = Key.CtrlMask | Key.Space;
                     }
+                    else if (wch >= (uint)Key.A - 64 && wch <= (uint)Key.Z - 64)
+                    {
+                        if ((Key)(wch + 64) != Key.J) k = Key.CtrlMask | (Key)(wch + 64);
+                    }
+                    else if (wch >= (uint)Key.A && wch <= (uint)Key.Z)
+                    {
+                        _keyModifiers.Shift = true;
+                    }
+
+                    break;
+                }
             }
 
             await RaiseKeyPressInternalAsync(k);
@@ -461,10 +462,10 @@ namespace Consolonia.PlatformSupport
                 case ConsoleKey.NoName:
                     return;
                 case 0:
-                    {
-                        bool _ = Enum.TryParse(key.ToString(), true, out consoleKey);
-                        break;
-                    }
+                {
+                    bool _ = Enum.TryParse(key.ToString(), true, out consoleKey);
+                    break;
+                }
             }
 
             if (((uint)keyValue & (uint)Key.CharMask) > 27)

--- a/src/Consolonia.PlatformSupport/CursesConsole.cs
+++ b/src/Consolonia.PlatformSupport/CursesConsole.cs
@@ -109,13 +109,11 @@ namespace Consolonia.PlatformSupport
             });
 
         private KeyModifiers _keyModifiers;
+        private Curses.Window _cursesWindow;
 
         public CursesConsole()
             : base(new AnsiConsoleOutput())
         {
-            // ReSharper disable VirtualMemberCallInConstructor
-            PrepareConsole();
-
             StartSizeCheckTimerAsync(2500);
             StartEventLoop();
         }
@@ -126,18 +124,8 @@ namespace Consolonia.PlatformSupport
 
         private void StartEventLoop()
         {
-            //todo: cleanup
-            Curses.initscr();
-            Curses.noecho();
-            Curses.cbreak();
-            Curses.doupdate();
-            Curses.raw();
-            Curses.Window.Standard.keypad(true);
-            Curses.mousemask(
-                Curses.Event.AllEvents | Curses.Event.ReportMousePosition,
-                out Curses.Event _);
-            /*Console.Out.Write("\x1b[?1003h");
-            Console.Out.Flush();*/
+            // ReSharper disable VirtualMemberCallInConstructor
+            PrepareConsole();
 
             Task _ = Task.Run(async () =>
             {
@@ -151,6 +139,32 @@ namespace Consolonia.PlatformSupport
                     await ProcessInput();
                 }
             });
+        }
+
+        public override void PrepareConsole()
+        {
+            _cursesWindow = Curses.initscr();
+            Curses.raw();
+            Curses.noecho();
+            _cursesWindow.keypad(true);
+            Curses.cbreak();
+            Curses.mousemask(
+                Curses.Event.AllEvents | Curses.Event.ReportMousePosition,
+                out Curses.Event _);
+
+            base.PrepareConsole();
+        }
+
+        public override void RestoreConsole()
+        {
+            base.RestoreConsole();
+
+            Curses.mousemask(0, out Curses.Event _);
+            Curses.nocbreak();
+            _cursesWindow.keypad(false);
+            Curses.echo();
+            Curses.noraw();
+            Curses.endwin();
         }
 
         public override void PauseIO(Task task)
@@ -230,200 +244,200 @@ namespace Consolonia.PlatformSupport
             {
                 // Special handling for ESC, we want to try to catch ESC+letter to simulate alt-letter as well as Alt-Fkey
                 case 27:
-                {
-                    Curses.timeout(200);
-
-                    code = Curses.get_wch(out int wch2);
-
-                    if (code == Curses.KEY_CODE_YES) k = Key.AltMask | MapCursesKey(wch);
-
-                    if (code == 0)
                     {
-                        //KeyEvent key;
+                        Curses.timeout(200);
 
-                        // The ESC-number handling, debatable.
-                        // Simulates the AltMask itself by pressing Alt + Space.
-                        if (wch2 == (int)Key.Space)
-                            k = Key.AltMask;
-                        else if (wch2 - (int)Key.Space >= (uint)Key.A && wch2 - (int)Key.Space <= (uint)Key.Z)
-                            k = (Key)((uint)Key.AltMask + (wch2 - (int)Key.Space));
-                        else if (wch2 >= (uint)Key.A - 64 && wch2 <= (uint)Key.Z - 64)
-                            k = (Key)((uint)(Key.AltMask | Key.CtrlMask) + (wch2 + 64));
-                        else if (wch2 >= (uint)Key.D0 && wch2 <= (uint)Key.D9)
-                            k = (Key)((uint)Key.AltMask + (uint)Key.D0 + (wch2 - (uint)Key.D0));
-                        else
-                            switch (wch2)
-                            {
-                                case 27:
-                                    k = (Key)wch2;
-                                    break;
-                                case Curses.KEY_CODE_SEQ:
+                        code = Curses.get_wch(out int wch2);
+
+                        if (code == Curses.KEY_CODE_YES) k = Key.AltMask | MapCursesKey(wch);
+
+                        if (code == 0)
+                        {
+                            //KeyEvent key;
+
+                            // The ESC-number handling, debatable.
+                            // Simulates the AltMask itself by pressing Alt + Space.
+                            if (wch2 == (int)Key.Space)
+                                k = Key.AltMask;
+                            else if (wch2 - (int)Key.Space >= (uint)Key.A && wch2 - (int)Key.Space <= (uint)Key.Z)
+                                k = (Key)((uint)Key.AltMask + (wch2 - (int)Key.Space));
+                            else if (wch2 >= (uint)Key.A - 64 && wch2 <= (uint)Key.Z - 64)
+                                k = (Key)((uint)(Key.AltMask | Key.CtrlMask) + (wch2 + 64));
+                            else if (wch2 >= (uint)Key.D0 && wch2 <= (uint)Key.D9)
+                                k = (Key)((uint)Key.AltMask + (uint)Key.D0 + (wch2 - (uint)Key.D0));
+                            else
+                                switch (wch2)
                                 {
-                                    int[] c = null;
-                                    while (code == 0)
-                                    {
-                                        code = Curses.get_wch(out wch2);
-                                        if (wch2 <= 0) continue;
-                                        int length = 1;
-                                        if (c != null)
-                                            length += c.Length;
-                                        Array.Resize(ref c, length);
-
-                                        c[^1] = wch2;
-                                    }
-
-                                    switch (c![0])
-                                    {
-                                        case 49 when c[1] == 59 && c[2] == 55 && c[3] >= 80 && c[3] <= 83:
-                                            // Ctrl+Alt+(F1 - F4)
-                                            wch2 = c[3] + 185;
-                                            k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
-                                            break;
-                                        case 49
-                                            when c[2] == 59 && c[3] == 55 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
-                                            // Ctrl+Alt+(F5 - F8)
-                                            wch2 = c[1] == 53 ? c[1] + 216 : c[1] + 215;
-                                            k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
-                                            break;
-                                        case 50
-                                            when c[2] == 59 && c[3] == 55 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
-                                            // Ctrl+Alt+(F9 - F12)
-                                            wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
-                                            k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
-                                            break;
-                                        case 49 when c[1] == 59 && c[2] == 56 && c[3] >= 80 && c[3] <= 83:
-                                            // Ctrl+Shift+Alt+(F1 - F4)
-                                            wch2 = c[3] + 185;
-                                            k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                            break;
-                                        case 49
-                                            when c[2] == 59 && c[3] == 56 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
-                                            // Ctrl+Shift+Alt+(F5 - F8)
-                                            wch2 = c[1] == 53 ? c[1] + 216 : c[1] + 215;
-                                            k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                            break;
-                                        case 50
-                                            when c[2] == 59 && c[3] == 56 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
-                                            // Ctrl+Shift+Alt+(F9 - F12)
-                                            wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
-                                            k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                            break;
-                                        case 49 when c[1] == 59 && c[2] == 52 && c[3] == 83:
-                                            // Shift+Alt+(F4)
-                                            wch2 = 268;
-                                            k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                            break;
-                                        case 49
-                                            when c[2] == 59 && c[3] == 52 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
-                                            // Shift+Alt+(F5 - F8)
-                                            wch2 = c[1] < 55 ? c[1] + 216 : c[1] + 215;
-                                            k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                            break;
-                                        case 50
-                                            when c[2] == 59 && c[3] == 52 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
-                                            // Shift+Alt+(F9 - F12)
-                                            wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
-                                            k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
-                                            break;
-                                        case 54 when c[1] == 59 && c[2] == 56 && c[3] == 126:
-                                            // Shift+Ctrl+Alt+KeyNPage
-                                            k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.PageDown;
-                                            break;
-                                        case 53 when c[1] == 59 && c[2] == 56 && c[3] == 126:
-                                            // Shift+Ctrl+Alt+KeyPPage
-                                            k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.PageUp;
-                                            break;
-                                        case 49 when c[1] == 59 && c[2] == 56 && c[3] == 72:
-                                            // Shift+Ctrl+Alt+KeyHome
-                                            k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.Home;
-                                            break;
-                                        case 49 when c[1] == 59 && c[2] == 56 && c[3] == 70:
-                                            // Shift+Ctrl+Alt+KeyEnd
-                                            k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.End;
-                                            break;
-
-                                        // ESC [200~ 
-                                        case 50 when c[1] == 48 && c[2] == 48 && c[3] == 126:
-                                            var sb = new StringBuilder();
-                                            for (int i = 4; i < c.Length; i++) sb.Append((char)c[i]);
-                                            string bufferText = sb.ToString();
-                                            int index = bufferText.IndexOf("\u001b[201~", StringComparison.Ordinal);
-                                            if (index > 0)
+                                    case 27:
+                                        k = (Key)wch2;
+                                        break;
+                                    case Curses.KEY_CODE_SEQ:
+                                        {
+                                            int[] c = null;
+                                            while (code == 0)
                                             {
-                                                string text = bufferText[..--index];
-                                                await DispatchInputAsync(() =>
-                                                {
-                                                    RaiseTextInput(text, (ulong)Stopwatch.GetTimestamp());
-                                                });
+                                                code = Curses.get_wch(out wch2);
+                                                if (wch2 <= 0) continue;
+                                                int length = 1;
+                                                if (c != null)
+                                                    length += c.Length;
+                                                Array.Resize(ref c, length);
+
+                                                c[^1] = wch2;
+                                            }
+
+                                            switch (c![0])
+                                            {
+                                                case 49 when c[1] == 59 && c[2] == 55 && c[3] >= 80 && c[3] <= 83:
+                                                    // Ctrl+Alt+(F1 - F4)
+                                                    wch2 = c[3] + 185;
+                                                    k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
+                                                    break;
+                                                case 49
+                                                    when c[2] == 59 && c[3] == 55 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
+                                                    // Ctrl+Alt+(F5 - F8)
+                                                    wch2 = c[1] == 53 ? c[1] + 216 : c[1] + 215;
+                                                    k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
+                                                    break;
+                                                case 50
+                                                    when c[2] == 59 && c[3] == 55 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
+                                                    // Ctrl+Alt+(F9 - F12)
+                                                    wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
+                                                    k = Key.CtrlMask | Key.AltMask | MapCursesKey(wch2);
+                                                    break;
+                                                case 49 when c[1] == 59 && c[2] == 56 && c[3] >= 80 && c[3] <= 83:
+                                                    // Ctrl+Shift+Alt+(F1 - F4)
+                                                    wch2 = c[3] + 185;
+                                                    k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                                    break;
+                                                case 49
+                                                    when c[2] == 59 && c[3] == 56 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
+                                                    // Ctrl+Shift+Alt+(F5 - F8)
+                                                    wch2 = c[1] == 53 ? c[1] + 216 : c[1] + 215;
+                                                    k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                                    break;
+                                                case 50
+                                                    when c[2] == 59 && c[3] == 56 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
+                                                    // Ctrl+Shift+Alt+(F9 - F12)
+                                                    wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
+                                                    k = Key.CtrlMask | Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                                    break;
+                                                case 49 when c[1] == 59 && c[2] == 52 && c[3] == 83:
+                                                    // Shift+Alt+(F4)
+                                                    wch2 = 268;
+                                                    k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                                    break;
+                                                case 49
+                                                    when c[2] == 59 && c[3] == 52 && c[4] == 126 && c[1] >= 53 && c[1] <= 57:
+                                                    // Shift+Alt+(F5 - F8)
+                                                    wch2 = c[1] < 55 ? c[1] + 216 : c[1] + 215;
+                                                    k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                                    break;
+                                                case 50
+                                                    when c[2] == 59 && c[3] == 52 && c[4] == 126 && c[1] >= 48 && c[1] <= 52:
+                                                    // Shift+Alt+(F9 - F12)
+                                                    wch2 = c[1] < 51 ? c[1] + 225 : c[1] + 224;
+                                                    k = Key.ShiftMask | Key.AltMask | MapCursesKey(wch2);
+                                                    break;
+                                                case 54 when c[1] == 59 && c[2] == 56 && c[3] == 126:
+                                                    // Shift+Ctrl+Alt+KeyNPage
+                                                    k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.PageDown;
+                                                    break;
+                                                case 53 when c[1] == 59 && c[2] == 56 && c[3] == 126:
+                                                    // Shift+Ctrl+Alt+KeyPPage
+                                                    k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.PageUp;
+                                                    break;
+                                                case 49 when c[1] == 59 && c[2] == 56 && c[3] == 72:
+                                                    // Shift+Ctrl+Alt+KeyHome
+                                                    k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.Home;
+                                                    break;
+                                                case 49 when c[1] == 59 && c[2] == 56 && c[3] == 70:
+                                                    // Shift+Ctrl+Alt+KeyEnd
+                                                    k = Key.ShiftMask | Key.CtrlMask | Key.AltMask | Key.End;
+                                                    break;
+
+                                                // ESC [200~ 
+                                                case 50 when c[1] == 48 && c[2] == 48 && c[3] == 126:
+                                                    var sb = new StringBuilder();
+                                                    for (int i = 4; i < c.Length; i++) sb.Append((char)c[i]);
+                                                    string bufferText = sb.ToString();
+                                                    int index = bufferText.IndexOf("\u001b[201~", StringComparison.Ordinal);
+                                                    if (index > 0)
+                                                    {
+                                                        string text = bufferText[..--index];
+                                                        await DispatchInputAsync(() =>
+                                                        {
+                                                            RaiseTextInput(text, (ulong)Stopwatch.GetTimestamp());
+                                                        });
+                                                    }
+
+                                                    break;
+
+                                                default:
+                                                    k = MapCursesKey(wch2);
+                                                    break;
                                             }
 
                                             break;
+                                        }
+                                    default:
+                                        {
+                                            // Unfortunately there are no way to differentiate Ctrl+Alt+alfa and Ctrl+Shift+Alt+alfa.
+                                            if (((Key)wch2 & Key.CtrlMask) != 0) _keyModifiers.Ctrl = true;
 
-                                        default:
-                                            k = MapCursesKey(wch2);
+                                            if (wch2 == 0)
+                                            {
+                                                k = Key.CtrlMask | Key.AltMask | Key.Space;
+                                            }
+                                            // ReSharper disable once ConditionIsAlwaysTrueOrFalse todo: check why
+                                            else if (wch >= (uint)Key.A && wch <= (uint)Key.Z)
+                                            {
+                                                _keyModifiers.Shift = true;
+                                                _keyModifiers.Alt = true;
+                                            }
+                                            else if (wch2 < 256)
+                                            {
+                                                k = (Key)wch2;
+                                                _keyModifiers.Alt = true;
+                                            }
+                                            else
+                                            {
+                                                k = (Key)((uint)(Key.AltMask | Key.CtrlMask) + wch2);
+                                            }
+
                                             break;
-                                    }
-
-                                    break;
+                                        }
                                 }
-                                default:
-                                {
-                                    // Unfortunately there are no way to differentiate Ctrl+Alt+alfa and Ctrl+Shift+Alt+alfa.
-                                    if (((Key)wch2 & Key.CtrlMask) != 0) _keyModifiers.Ctrl = true;
+                        }
+                        else
+                        {
+                            k = Key.Esc;
+                        }
 
-                                    if (wch2 == 0)
-                                    {
-                                        k = Key.CtrlMask | Key.AltMask | Key.Space;
-                                    }
-                                    // ReSharper disable once ConditionIsAlwaysTrueOrFalse todo: check why
-                                    else if (wch >= (uint)Key.A && wch <= (uint)Key.Z)
-                                    {
-                                        _keyModifiers.Shift = true;
-                                        _keyModifiers.Alt = true;
-                                    }
-                                    else if (wch2 < 256)
-                                    {
-                                        k = (Key)wch2;
-                                        _keyModifiers.Alt = true;
-                                    }
-                                    else
-                                    {
-                                        k = (Key)((uint)(Key.AltMask | Key.CtrlMask) + wch2);
-                                    }
-
-                                    break;
-                                }
-                            }
+                        break;
                     }
-                    else
-                    {
-                        k = Key.Esc;
-                    }
-
-                    break;
-                }
                 case Curses.KeyTab:
                     k = MapCursesKey(wch);
                     break;
                 default:
-                {
-                    // Unfortunately there are no way to differentiate Ctrl+alfa and Ctrl+Shift+alfa.
-                    k = (Key)wch;
-                    if (wch == 0)
                     {
-                        k = Key.CtrlMask | Key.Space;
-                    }
-                    else if (wch >= (uint)Key.A - 64 && wch <= (uint)Key.Z - 64)
-                    {
-                        if ((Key)(wch + 64) != Key.J) k = Key.CtrlMask | (Key)(wch + 64);
-                    }
-                    else if (wch >= (uint)Key.A && wch <= (uint)Key.Z)
-                    {
-                        _keyModifiers.Shift = true;
-                    }
+                        // Unfortunately there are no way to differentiate Ctrl+alfa and Ctrl+Shift+alfa.
+                        k = (Key)wch;
+                        if (wch == 0)
+                        {
+                            k = Key.CtrlMask | Key.Space;
+                        }
+                        else if (wch >= (uint)Key.A - 64 && wch <= (uint)Key.Z - 64)
+                        {
+                            if ((Key)(wch + 64) != Key.J) k = Key.CtrlMask | (Key)(wch + 64);
+                        }
+                        else if (wch >= (uint)Key.A && wch <= (uint)Key.Z)
+                        {
+                            _keyModifiers.Shift = true;
+                        }
 
-                    break;
-                }
+                        break;
+                    }
             }
 
             await RaiseKeyPressInternalAsync(k);
@@ -447,10 +461,10 @@ namespace Consolonia.PlatformSupport
                 case ConsoleKey.NoName:
                     return;
                 case 0:
-                {
-                    bool _ = Enum.TryParse(key.ToString(), true, out consoleKey);
-                    break;
-                }
+                    {
+                        bool _ = Enum.TryParse(key.ToString(), true, out consoleKey);
+                        break;
+                    }
             }
 
             if (((uint)keyValue & (uint)Key.CharMask) > 27)


### PR DESCRIPTION
* Always dispose console driver
* Implment CursorsConsole .PrepareConsole() and RestoreConsole() correctly.

> NOTE: This is correctly cleaning up curses, but there is a dotnet platform bug https://github.com/dotnet/runtime/pull/111272 which was just merged in december which will fix this in dotnet 10.x release which is that dotnet is not correctly reseting the console state when a dotnet console app exits.

