### PR TITLE
Doubleclick doesn't work anymore 

### DIFF
--- a/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
@@ -317,7 +317,7 @@ namespace Consolonia.Core.Infrastructure
         private void ConsoleOnMouseEvent(RawPointerEventType type, Point point, Vector? wheelDelta,
             RawInputModifiers modifiers)
         {
-            ulong timestamp = (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds();
+            ulong timestamp = (ulong)Environment.TickCount64;
             // ReSharper disable once SwitchStatementMissingSomeEnumCasesNoDefault
             switch (type)
             {

--- a/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
@@ -317,7 +317,7 @@ namespace Consolonia.Core.Infrastructure
         private void ConsoleOnMouseEvent(RawPointerEventType type, Point point, Vector? wheelDelta,
             RawInputModifiers modifiers)
         {
-            ulong timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            ulong timestamp = (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds();
             // ReSharper disable once SwitchStatementMissingSomeEnumCasesNoDefault
             switch (type)
             {

--- a/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
@@ -317,7 +317,7 @@ namespace Consolonia.Core.Infrastructure
         private void ConsoleOnMouseEvent(RawPointerEventType type, Point point, Vector? wheelDelta,
             RawInputModifiers modifiers)
         {
-            ulong timestamp = (ulong)Stopwatch.GetTimestamp();
+            ulong timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             // ReSharper disable once SwitchStatementMissingSomeEnumCasesNoDefault
             switch (type)
             {

--- a/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
@@ -88,10 +88,10 @@ namespace Consolonia.Core.Infrastructure
                     await DispatchInputAsync(() =>
                     {
                         RaiseKeyPress(key, consoleKeyInfo.KeyChar, rawInputModifiers, true,
-                            (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
+                            (ulong)Environment.TickCount64);
                         Thread.Yield(); //todo: low is yielding necessary here?
                         RaiseKeyPress(key, consoleKeyInfo.KeyChar, rawInputModifiers, false,
-                            (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
+                            (ulong)Environment.TickCount64);
                         Thread.Yield();
                     });
                 }

--- a/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
@@ -89,10 +89,10 @@ namespace Consolonia.Core.Infrastructure
                     await DispatchInputAsync(() =>
                     {
                         RaiseKeyPress(key, consoleKeyInfo.KeyChar, rawInputModifiers, true,
-                            (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                            (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
                         Thread.Yield(); //todo: low is yielding necessary here?
                         RaiseKeyPress(key, consoleKeyInfo.KeyChar, rawInputModifiers, false,
-                            (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                            (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
                         Thread.Yield();
                     });
                 }

--- a/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
@@ -89,10 +89,10 @@ namespace Consolonia.Core.Infrastructure
                     await DispatchInputAsync(() =>
                     {
                         RaiseKeyPress(key, consoleKeyInfo.KeyChar, rawInputModifiers, true,
-                            (ulong)Stopwatch.GetTimestamp());
+                            (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
                         Thread.Yield(); //todo: low is yielding necessary here?
                         RaiseKeyPress(key, consoleKeyInfo.KeyChar, rawInputModifiers, false,
-                            (ulong)Stopwatch.GetTimestamp());
+                            (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
                         Thread.Yield();
                     });
                 }

--- a/src/Consolonia.NUnit/UnitTestConsole.cs
+++ b/src/Consolonia.NUnit/UnitTestConsole.cs
@@ -121,7 +121,7 @@ namespace Consolonia.NUnit
             foreach (char c in input)
             {
                 const Key key = Key.None;
-                ulong timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                ulong timestamp = (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds();
                 // todo: check why Yield is not enough: https://github.com/jinek/Consolonia/runs/7055199426?check_suite_focus=true
                 const ulong interval = 50;
                 KeyEvent?.Invoke(key, c, RawInputModifiers.None, true, timestamp);
@@ -160,7 +160,7 @@ namespace Consolonia.NUnit
 
         public async Task KeyInput(Key key, RawInputModifiers modifiers = RawInputModifiers.None)
         {
-            ulong timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            ulong timestamp = (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds();
             KeyEvent?.Invoke(key, char.MinValue /*will be skipped as control character*/, modifiers, true, timestamp);
             await Task.Yield();
             KeyEvent?.Invoke(key, char.MinValue /*will be skipped as control character*/, modifiers, false,

--- a/src/Consolonia.NUnit/UnitTestConsole.cs
+++ b/src/Consolonia.NUnit/UnitTestConsole.cs
@@ -120,7 +120,7 @@ namespace Consolonia.NUnit
             foreach (char c in input)
             {
                 const Key key = Key.None;
-                ulong timestamp = (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds();
+                ulong timestamp = (ulong)Environment.TickCount64;
                 // todo: check why Yield is not enough: https://github.com/jinek/Consolonia/runs/7055199426?check_suite_focus=true
                 const ulong interval = 50;
                 KeyEvent?.Invoke(key, c, RawInputModifiers.None, true, timestamp);
@@ -159,7 +159,7 @@ namespace Consolonia.NUnit
 
         public async Task KeyInput(Key key, RawInputModifiers modifiers = RawInputModifiers.None)
         {
-            ulong timestamp = (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds();
+            ulong timestamp = (ulong)Environment.TickCount64;
             KeyEvent?.Invoke(key, char.MinValue /*will be skipped as control character*/, modifiers, true, timestamp);
             await Task.Yield();
             KeyEvent?.Invoke(key, char.MinValue /*will be skipped as control character*/, modifiers, false,

--- a/src/Consolonia.NUnit/UnitTestConsole.cs
+++ b/src/Consolonia.NUnit/UnitTestConsole.cs
@@ -121,7 +121,7 @@ namespace Consolonia.NUnit
             foreach (char c in input)
             {
                 const Key key = Key.None;
-                ulong timestamp = (ulong)Stopwatch.GetTimestamp();
+                ulong timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 // todo: check why Yield is not enough: https://github.com/jinek/Consolonia/runs/7055199426?check_suite_focus=true
                 const ulong interval = 50;
                 KeyEvent?.Invoke(key, c, RawInputModifiers.None, true, timestamp);
@@ -160,7 +160,7 @@ namespace Consolonia.NUnit
 
         public async Task KeyInput(Key key, RawInputModifiers modifiers = RawInputModifiers.None)
         {
-            ulong timestamp = (ulong)Stopwatch.GetTimestamp();
+            ulong timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             KeyEvent?.Invoke(key, char.MinValue /*will be skipped as control character*/, modifiers, true, timestamp);
             await Task.Yield();
             KeyEvent?.Invoke(key, char.MinValue /*will be skipped as control character*/, modifiers, false,

--- a/src/Consolonia.PlatformSupport/CursesConsole.cs
+++ b/src/Consolonia.PlatformSupport/CursesConsole.cs
@@ -368,7 +368,7 @@ namespace Consolonia.PlatformSupport
                                                 string text = bufferText[..--index];
                                                 await DispatchInputAsync(() =>
                                                 {
-                                                    RaiseTextInput(text, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                                                    RaiseTextInput(text, (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
                                                 });
                                             }
 
@@ -486,10 +486,10 @@ namespace Consolonia.PlatformSupport
             await DispatchInputAsync(() =>
             {
                 RaiseKeyPress(convertToKey,
-                    character, modifiers, true, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                    character, modifiers, true, (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
                 Thread.Yield();
                 RaiseKeyPress(convertToKey,
-                    character, modifiers, false, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                    character, modifiers, false, (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
             });
         }
 

--- a/src/Consolonia.PlatformSupport/CursesConsole.cs
+++ b/src/Consolonia.PlatformSupport/CursesConsole.cs
@@ -367,7 +367,7 @@ namespace Consolonia.PlatformSupport
                                                 string text = bufferText[..--index];
                                                 await DispatchInputAsync(() =>
                                                 {
-                                                    RaiseTextInput(text, (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
+                                                    RaiseTextInput(text, (ulong)Environment.TickCount64);
                                                 });
                                             }
 
@@ -485,10 +485,10 @@ namespace Consolonia.PlatformSupport
             await DispatchInputAsync(() =>
             {
                 RaiseKeyPress(convertToKey,
-                    character, modifiers, true, (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
+                    character, modifiers, true, (ulong)Environment.TickCount64);
                 Thread.Yield();
                 RaiseKeyPress(convertToKey,
-                    character, modifiers, false, (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
+                    character, modifiers, false, (ulong)Environment.TickCount64);
             });
         }
 

--- a/src/Consolonia.PlatformSupport/CursesConsole.cs
+++ b/src/Consolonia.PlatformSupport/CursesConsole.cs
@@ -368,7 +368,7 @@ namespace Consolonia.PlatformSupport
                                                 string text = bufferText[..--index];
                                                 await DispatchInputAsync(() =>
                                                 {
-                                                    RaiseTextInput(text, (ulong)Stopwatch.GetTimestamp());
+                                                    RaiseTextInput(text, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
                                                 });
                                             }
 
@@ -486,10 +486,10 @@ namespace Consolonia.PlatformSupport
             await DispatchInputAsync(() =>
             {
                 RaiseKeyPress(convertToKey,
-                    character, modifiers, true, (ulong)Stopwatch.GetTimestamp());
+                    character, modifiers, true, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
                 Thread.Yield();
                 RaiseKeyPress(convertToKey,
-                    character, modifiers, false, (ulong)Stopwatch.GetTimestamp());
+                    character, modifiers, false, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
             });
         }
 

--- a/src/Consolonia.PlatformSupport/Win32Console.cs
+++ b/src/Consolonia.PlatformSupport/Win32Console.cs
@@ -193,7 +193,7 @@ namespace Consolonia.PlatformSupport
                                     // buffered text matches clipboard, emit CTRL+V sequence and ignore buffered keyboard events
                                     //foreach (KEY_EVENT_RECORD ctrlVEvent in CtrlVKeyEvents)
                                     //    HandleKeyInput(ctrlVEvent);
-                                    RaiseTextInput(currentBufferText, 
+                                    RaiseTextInput(currentBufferText,
                                         (ulong)Environment.TickCount64);
 
                                     // process remaining input records

--- a/src/Consolonia.PlatformSupport/Win32Console.cs
+++ b/src/Consolonia.PlatformSupport/Win32Console.cs
@@ -194,7 +194,7 @@ namespace Consolonia.PlatformSupport
                                     // buffered text matches clipboard, emit CTRL+V sequence and ignore buffered keyboard events
                                     //foreach (KEY_EVENT_RECORD ctrlVEvent in CtrlVKeyEvents)
                                     //    HandleKeyInput(ctrlVEvent);
-                                    RaiseTextInput(currentBufferText, (ulong)Stopwatch.GetTimestamp());
+                                    RaiseTextInput(currentBufferText, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
 
                                     // process remaining input records
                                     for (++i; i < inputRecords.Length; i++)
@@ -364,7 +364,7 @@ namespace Consolonia.PlatformSupport
             if (key == Key.LeftAlt || key == Key.RightAlt)
                 modifiers |= RawInputModifiers.Alt;
             RaiseKeyPress(key,
-                character, modifiers, keyEvent.bKeyDown, (ulong)Stopwatch.GetTimestamp());
+                character, modifiers, keyEvent.bKeyDown, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
         }
     }
 }

--- a/src/Consolonia.PlatformSupport/Win32Console.cs
+++ b/src/Consolonia.PlatformSupport/Win32Console.cs
@@ -194,7 +194,7 @@ namespace Consolonia.PlatformSupport
                                     // buffered text matches clipboard, emit CTRL+V sequence and ignore buffered keyboard events
                                     //foreach (KEY_EVENT_RECORD ctrlVEvent in CtrlVKeyEvents)
                                     //    HandleKeyInput(ctrlVEvent);
-                                    RaiseTextInput(currentBufferText, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                                    RaiseTextInput(currentBufferText, (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
 
                                     // process remaining input records
                                     for (++i; i < inputRecords.Length; i++)
@@ -364,7 +364,7 @@ namespace Consolonia.PlatformSupport
             if (key == Key.LeftAlt || key == Key.RightAlt)
                 modifiers |= RawInputModifiers.Alt;
             RaiseKeyPress(key,
-                character, modifiers, keyEvent.bKeyDown, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                character, modifiers, keyEvent.bKeyDown, (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
         }
     }
 }

--- a/src/Consolonia.PlatformSupport/Win32Console.cs
+++ b/src/Consolonia.PlatformSupport/Win32Console.cs
@@ -194,7 +194,7 @@ namespace Consolonia.PlatformSupport
                                     //foreach (KEY_EVENT_RECORD ctrlVEvent in CtrlVKeyEvents)
                                     //    HandleKeyInput(ctrlVEvent);
                                     RaiseTextInput(currentBufferText, 
-                                        (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
+                                        (ulong)Environment.TickCount64);
 
                                     // process remaining input records
                                     for (++i; i < inputRecords.Length; i++)
@@ -364,7 +364,7 @@ namespace Consolonia.PlatformSupport
             if (key == Key.LeftAlt || key == Key.RightAlt)
                 modifiers |= RawInputModifiers.Alt;
             RaiseKeyPress(key,
-                character, modifiers, keyEvent.bKeyDown, (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds());
+                character, modifiers, keyEvent.bKeyDown, (ulong)Environment.TickCount64);
         }
     }
 }


### PR DESCRIPTION
When we consolidated the code for dispatching inputs we started sending event timestamps as ticks, not milliseconds.  The avalonia code is expecting timestamp to be units of milliseconds and calculates double click period by milliseconds between clicks. The delta of ticks based timestamps was way larger than the millisecond value for double click detection and so no translation to double click was happening.

This fix changes code from using Stopwatch.GetTimestamp() to DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
