### PR TITLE
Drag and drop works now

### DIFF
--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml
@@ -1,0 +1,47 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:console="https://github.com/jinek/consolonia"
+             mc:Ignorable="d"
+             x:Class="Consolonia.Gallery.Gallery.GalleryViews.GalleryDragAndDrop">
+
+    <StackPanel Orientation="Vertical" Spacing="1">
+        <TextBlock Classes="h2">Example of Drag+Drop capabilities</TextBlock>
+
+        <StackPanel Orientation="Vertical">
+            <StackPanel Margin="1">
+                <Border Name="DragMeText" BorderThickness="1" BorderBrush="{StaticResource ThemeForegroundBrush}"
+                        Classes="draggable">
+                    <TextBlock Name="DragStateText" TextWrapping="Wrap">Drag Me (text)</TextBlock>
+                </Border>
+                <Border Name="DragMeFiles" BorderThickness="1" BorderBrush="{StaticResource ThemeForegroundBrush}"
+                        Classes="draggable">
+                    <TextBlock Name="DragStateFiles" TextWrapping="Wrap">Drag Me (files)</TextBlock>
+                </Border>
+                <Border Name="DragMeCustom" BorderThickness="1" BorderBrush="{StaticResource ThemeForegroundBrush}"
+                        Classes="draggable">
+                    <TextBlock Name="DragStateCustom" TextWrapping="Wrap">Drag Me (custom)</TextBlock>
+                </Border>
+            </StackPanel>
+
+            <StackPanel Margin="1"
+                        Orientation="Horizontal"
+                        Spacing="1">
+                <TextBlock Foreground="{StaticResource ThemeSelectionForegroundBrush}"
+                           Name="CopyTarget"
+                        Padding="1"
+                        Background="{StaticResource ThemeSelectionBackgroundBrush}"
+                        DragDrop.AllowDrop="True"
+                           TextWrapping="Wrap">Drop some text or files here (Copy)</TextBlock>
+                <TextBlock Name="MoveTarget" DragDrop.AllowDrop="True"
+                           Padding="1" Background="{StaticResource ThemeSelectionBackgroundBrush}"
+                           Foreground="{StaticResource ThemeSelectionForegroundBrush}"
+                           TextWrapping="Wrap">Drop some text or files here (Move)</TextBlock>
+            </StackPanel>
+        </StackPanel>
+
+        <TextBlock x:Name="DropState" TextWrapping="Wrap" />
+    </StackPanel>
+
+</UserControl>

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml.cs
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using Consolonia.Core.Infrastructure;
+
+namespace Consolonia.Gallery.Gallery.GalleryViews
+{
+    public partial class GalleryDragAndDrop : UserControl
+    {
+        private readonly TextBlock _dropState;
+        private const string CustomFormat = "application/xxx-avalonia-controlcatalog-custom";
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        public GalleryDragAndDrop()
+        {
+            InitializeComponent();
+            _dropState = this.Get<TextBlock>("DropState");
+
+            int textCount = 0;
+
+            SetupDnd(
+                "Text",
+                d => d.Set(DataFormats.Text, $"Text was dragged {++textCount} times"),
+                DragDropEffects.Copy | DragDropEffects.Move | DragDropEffects.Link);
+
+            SetupDnd(
+                "Custom",
+                d => d.Set(CustomFormat, "Test123"),
+                DragDropEffects.Move);
+
+            SetupDnd(
+                "Files",
+                async d =>
+                {
+                    d.Set(DataFormats.Files, new[] { new SystemStorageFile(@"file.txt") });
+                },
+                DragDropEffects.Copy);
+        }
+
+        private void SetupDnd(string suffix, Action<DataObject> factory, DragDropEffects effects) =>
+            SetupDnd(
+                suffix,
+                o =>
+                {
+                    factory(o);
+                    return Task.CompletedTask;
+                },
+                effects);
+
+        private void SetupDnd(string suffix, Func<DataObject, Task> factory, DragDropEffects effects)
+        {
+            var dragMe = this.Get<Border>("DragMe" + suffix);
+            var dragState = this.Get<TextBlock>("DragState" + suffix);
+
+            async void DoDrag(object? sender, PointerPressedEventArgs e)
+            {
+                var dragData = new DataObject();
+                await factory(dragData);
+
+                dragState.Text = "Dragging...";
+                var result = await DragDrop.DoDragDrop(e, dragData, effects);
+                switch (result)
+                {
+                    case DragDropEffects.Move:
+                        dragState.Text = "Data was moved";
+                        break;
+                    case DragDropEffects.Copy:
+                        dragState.Text = "Data was copied";
+                        break;
+                    case DragDropEffects.Link:
+                        dragState.Text = "Data was linked";
+                        break;
+                    case DragDropEffects.None:
+                        dragState.Text = "The drag operation was canceled";
+                        break;
+                    default:
+                        dragState.Text = "Unknown result";
+                        break;
+                }
+            }
+
+            void DragOver(object? sender, DragEventArgs e)
+            {
+                if (e.Source is Control c && c.Name == "MoveTarget")
+                {
+                    e.DragEffects = e.DragEffects & (DragDropEffects.Move);
+                }
+                else
+                {
+                    e.DragEffects = e.DragEffects & (DragDropEffects.Copy);
+                }
+
+                // Only allow if the dragged data contains text or filenames.
+                if (!e.Data.Contains(DataFormats.Text)
+                    && !e.Data.Contains(DataFormats.Files)
+                    && !e.Data.Contains(CustomFormat))
+                    e.DragEffects = DragDropEffects.None;
+            }
+
+            async void Drop(object? sender, DragEventArgs e)
+            {
+                if (e.Source is Control c && c.Name == "MoveTarget")
+                {
+                    e.DragEffects = e.DragEffects & (DragDropEffects.Move);
+                }
+                else
+                {
+                    e.DragEffects = e.DragEffects & (DragDropEffects.Copy);
+                }
+
+                if (e.Data.Contains(DataFormats.Text))
+                {
+                    _dropState.Text = $"({e.DragEffects}) {e.Data.GetText()}";
+                }
+                else if (e.Data.Contains(DataFormats.Files))
+                {
+                    var files = e.Data.GetFiles() ?? Array.Empty<IStorageItem>();
+                    var contentStr = $"({e.DragEffects}) {Environment.NewLine}";
+
+                    foreach (var item in files)
+                    {
+                        if (item is IStorageFile file)
+                        {
+                            //var content = await DialogsPage.ReadTextFromFile(file, 500);
+                            contentStr += $"File {file.Name}:{Environment.NewLine}";
+                        }
+                        else if (item is IStorageFolder folder)
+                        {
+                            var childrenCount = 0;
+                            await foreach (var _ in folder.GetItemsAsync())
+                            {
+                                childrenCount++;
+                            }
+                            contentStr += $"Folder {item.Name}: items {childrenCount}{Environment.NewLine}{Environment.NewLine}";
+                        }
+                    }
+
+                    _dropState.Text = contentStr;
+                }
+#pragma warning disable CS0618 // Type or member is obsolete
+                else if (e.Data.Contains(DataFormats.FileNames))
+                {
+                    var files = e.Data.GetFileNames();
+                    _dropState.Text = $"({e.DragEffects})  {string.Join(Environment.NewLine, files ?? Array.Empty<string>())}";
+                }
+#pragma warning restore CS0618 // Type or member is obsolete
+                else if (e.Data.Contains(CustomFormat))
+                {
+                    _dropState.Text = $"({e.DragEffects})  Custom: {e.Data.Get(CustomFormat)}";
+                }
+            }
+
+            dragMe.PointerPressed += DoDrag;
+
+            AddHandler(DragDrop.DropEvent, Drop);
+            AddHandler(DragDrop.DragOverEvent, DragOver);
+        }
+
+    }
+}

--- a/src/Consolonia.PlatformSupport/Win32Console.cs
+++ b/src/Consolonia.PlatformSupport/Win32Console.cs
@@ -283,46 +283,65 @@ namespace Consolonia.PlatformSupport
                         inputModifiers);
                     break;
 
+                case MOUSE_EVENT_FLAG.MOUSE_MOVED | MOUSE_EVENT_FLAG.DOUBLE_CLICK:
+                    // Win32 maps MOUSE_DOWN/DRAG => as MOVED|DOUBLE_CLICK 
+                    // Avalonia wants it to just be MOUSE_DOWN, and then subsequent MOUSE_MOVE events
                 case MOUSE_EVENT_FLAG.NONE:
-                    foreach (MOUSE_BUTTON_STATE flag in Enum.GetValues<MOUSE_BUTTON_STATE>())
-                        if (!_mouseButtonsState.HasFlag(flag) && mouseEvent.dwButtonState.HasFlag(flag))
-                        {
-                            // If we went from flag off to flag on
-                            RawPointerEventType buttonDownEventType =
-                                MouseButtonDownEventTypeTranslator.Translate(flag);
+                    {
+                        bool emitted = false;
+                        foreach (MOUSE_BUTTON_STATE flag in Enum.GetValues<MOUSE_BUTTON_STATE>())
+                            if (!_mouseButtonsState.HasFlag(flag) && mouseEvent.dwButtonState.HasFlag(flag))
+                            {
+                                // If we went from flag off to flag on
+                                RawPointerEventType buttonDownEventType =
+                                    MouseButtonDownEventTypeTranslator.Translate(flag);
 #pragma warning disable IDE0034
-                            // Simplify 'default' expression
-                            if (buttonDownEventType != default)
-                                RaiseMouseEvent(buttonDownEventType,
-                                    point,
-                                    null,
-                                    inputModifiers);
+                                // Simplify 'default' expression
+                                if (buttonDownEventType != default)
+                                {
+                                    RaiseMouseEvent(buttonDownEventType,
+                                        point,
+                                        null,
+                                        inputModifiers);
+                                    _mouseButtonsState = mouseEvent.dwButtonState;
+                                    emitted = true;
+                                    break;
+                                }
 #pragma warning restore IDE0034
-                            // Simplify 'default' expression
-                        }
+                                // Simplify 'default' expression
+                            }
 
-                        else if (_mouseButtonsState.HasFlag(flag) && !mouseEvent.dwButtonState.HasFlag(flag))
-                        {
-                            // If we went from flag On to flag off
-                            RawPointerEventType buttonEventType = MouseButtonUpEventTypeTranslator.Translate(flag);
+                            else if (_mouseButtonsState.HasFlag(flag) && !mouseEvent.dwButtonState.HasFlag(flag))
+                            {
+                                // If we went from flag On to flag off
+                                RawPointerEventType buttonEventType = MouseButtonUpEventTypeTranslator.Translate(flag);
 #pragma warning disable IDE0034
-                            // Simplify 'default' expression
-                            if (buttonEventType != default)
-                                RaiseMouseEvent(buttonEventType,
-                                    point,
-                                    null,
-                                    inputModifiers);
+                                // Simplify 'default' expression
+                                if (buttonEventType != default)
+                                {
+
+                                    RaiseMouseEvent(buttonEventType,
+                                        point,
+                                        null,
+                                        inputModifiers);
+                                    _mouseButtonsState = mouseEvent.dwButtonState;
+                                    emitted = true;
+                                    break;
+                                }
 #pragma warning restore IDE0034
-                            // Simplify 'default' expression
-                        }
-                        else
+                                // Simplify 'default' expression
+                            }
+
+                        if (!emitted)
                         {
+                            // If we didn't emit any button up/down transition events, emit a move event
                             RaiseMouseEvent(eventType,
                                 point,
-                                null,
+                                wheelDelta,
                                 inputModifiers);
+                            _mouseButtonsState = mouseEvent.dwButtonState;
                         }
-
+                    }
                     break;
 
                 case MOUSE_EVENT_FLAG.MOUSE_WHEELED:
@@ -341,11 +360,6 @@ namespace Consolonia.PlatformSupport
                         wheelDelta,
                         inputModifiers);
                     _mouseButtonsState = mouseEvent.dwButtonState;
-                    break;
-                case MOUSE_EVENT_FLAG.MOUSE_MOVED | MOUSE_EVENT_FLAG.DOUBLE_CLICK:
-                    RaiseMouseEvent(RawPointerEventType.LeftButtonDown, point, null, inputModifiers);
-                    RaiseMouseEvent(RawPointerEventType.Move, point, null, inputModifiers);
-                    //RaiseMouseEvent(RawPointerEventType.LeftButtonUp, point, null, inputModifiers);
                     break;
                 default:
                     throw new InvalidOperationException(mouseEvent.dwEventFlags.ToString());

--- a/src/Consolonia.Themes/Templates/Controls/ScrollBar.axaml
+++ b/src/Consolonia.Themes/Templates/Controls/ScrollBar.axaml
@@ -15,6 +15,18 @@
             <ControlTemplate>
                 <Border Background="{TemplateBinding BorderBrush}">
                     <Grid RowDefinitions="Auto,*,Auto">
+                        <RepeatButton Name="PART_LineUpButton"
+                              Grid.Row="0"
+                              Grid.Column="0"
+                              MinWidth="{DynamicResource ScrollBarThickness}"
+                              VerticalAlignment="Center"
+                              Classes="repeat"
+                              Focusable="False">
+                            <helpers:SymbolsControl HorizontalAlignment="Center"
+                                                    Foreground="{TemplateBinding Foreground}"
+                                                    Text="▲" />
+                        </RepeatButton>
+
                         <Border Grid.Row="1"
                                 BorderThickness="0"
                                 Background="{TemplateBinding Background}">
@@ -23,10 +35,6 @@
                                                     Text="░"
                                                     Foreground="{TemplateBinding BorderBrush}" />
                         </Border>
-                        <helpers:SymbolsControl HorizontalAlignment="Center"
-                                                Grid.Row="0"
-                                                Foreground="{TemplateBinding Foreground}"
-                                                Text="▲" />
                         <Track Grid.Row="1"
                                Minimum="{TemplateBinding Minimum}"
                                Maximum="{TemplateBinding Maximum}"
@@ -34,14 +42,31 @@
                                ViewportSize="{TemplateBinding ViewportSize}"
                                Orientation="{TemplateBinding Orientation}"
                                IsDirectionReversed="True">
+                            <Track.DecreaseButton>
+                                <RepeatButton Name="PART_PageUpButton"
+                                              Classes="repeattrack"
+                                              Focusable="False" />
+                            </Track.DecreaseButton>
+                            <Track.IncreaseButton>
+                                <RepeatButton Name="PART_PageDownButton"
+                                              Classes="repeattrack"
+                                              Focusable="False" />
+                            </Track.IncreaseButton>
                             <Thumb Name="thumb" />
                         </Track>
-                        <helpers:SymbolsControl HorizontalAlignment="Center"
-                                                Foreground="{TemplateBinding Foreground}"
-                                                Grid.Row="2"
-                                                Focusable="False"
-                                                MinHeight="1"
-                                                Text="▼" />
+                        <RepeatButton Name="PART_LineDownButton"
+                              Grid.Row="2"
+                              Grid.Column="2"
+                              MinWidth="{DynamicResource ScrollBarThickness}"
+                              VerticalAlignment="Center"
+                              Classes="repeat"
+                              Focusable="False">
+                            <helpers:SymbolsControl HorizontalAlignment="Center"
+                                                    Foreground="{TemplateBinding Foreground}"
+                                                    Focusable="False"
+                                                    MinHeight="1"
+                                                    Text="▼" />
+                        </RepeatButton>
                     </Grid>
                 </Border>
             </ControlTemplate>
@@ -51,6 +76,17 @@
                 <ControlTemplate>
                     <Border Background="{TemplateBinding BorderBrush}">
                         <Grid ColumnDefinitions="Auto,*,Auto">
+                            <RepeatButton Name="PART_LineUpButton"
+                                  Grid.Row="0"
+                                  MinHeight="{DynamicResource ScrollBarThickness}"
+                                  HorizontalAlignment="Center"
+                                  Classes="repeat"
+                                  Focusable="False">
+                                <helpers:SymbolsControl HorizontalAlignment="Center"
+                                                        Foreground="{TemplateBinding Foreground}"
+                                                        Text="◄" />
+                            </RepeatButton>
+
                             <Border Grid.Column="1"
                                     BorderThickness="0"
                                     Background="{TemplateBinding Background}">
@@ -59,22 +95,36 @@
                                                         Text="░"
                                                         Foreground="{TemplateBinding BorderBrush}" />
                             </Border>
-                            <helpers:SymbolsControl HorizontalAlignment="Center"
-                                                    Grid.Column="0"
-                                                    Foreground="{TemplateBinding Foreground}"
-                                                    Text="◄" />
                             <Track Grid.Column="1"
                                    Minimum="{TemplateBinding Minimum}"
                                    Maximum="{TemplateBinding Maximum}"
                                    Value="{TemplateBinding Value, Mode=TwoWay}"
                                    ViewportSize="{TemplateBinding ViewportSize}"
                                    Orientation="{TemplateBinding Orientation}">
+                                <Track.DecreaseButton>
+                                    <RepeatButton Name="PART_PageUpButton"
+                                                  Classes="repeattrack"
+                                                  Focusable="False" />
+                                </Track.DecreaseButton>
+                                <Track.IncreaseButton>
+                                    <RepeatButton Name="PART_PageDownButton"
+                                                  Classes="repeattrack"
+                                                  Focusable="False" />
+                                </Track.IncreaseButton>
                                 <Thumb Name="thumb" />
                             </Track>
-                            <helpers:SymbolsControl HorizontalAlignment="Center"
-                                                    Grid.Column="2"
-                                                    Foreground="{TemplateBinding Foreground}"
-                                                    Text="►" />
+                            <RepeatButton Name="PART_LineDownButton"
+                                  Grid.Row="2"
+                                  Grid.Column="2"
+                                  MinHeight="{DynamicResource ScrollBarThickness}"
+                                  HorizontalAlignment="Center"
+                                  Classes="repeat"
+                                  Focusable="False">
+                                <helpers:SymbolsControl HorizontalAlignment="Center"
+                                                        Foreground="{TemplateBinding Foreground}"
+                                                        Text="►" />
+                            </RepeatButton>
+
                         </Grid>
                     </Border>
                 </ControlTemplate>


### PR DESCRIPTION
* Win32 was not modeling click drag the way Avalonia expects. Win32 drive generates MOVE/DOUBLECLICK, which we were mapping to MOVE and UP events.  Now we map to the way that Avalonia expects, which is a MOUSE BUTTON DOWN EVENT followed by MOVE with MOUSE_BUTTON_DOWN
 
* Added gallery page for drag drop
![dragAndDrop](https://github.com/user-attachments/assets/43378d09-9d0b-4f22-9f6d-4a43e376690e)
