### PR TITLE
Drag and drop works now

### DIFF
--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml
@@ -1,0 +1,47 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:console="https://github.com/jinek/consolonia"
+             mc:Ignorable="d"
+             x:Class="Consolonia.Gallery.Gallery.GalleryViews.GalleryDragAndDrop">
+
+    <StackPanel Orientation="Vertical" Spacing="1">
+        <TextBlock Classes="h2">Example of Drag+Drop capabilities</TextBlock>
+
+        <StackPanel Orientation="Vertical">
+            <StackPanel Margin="1">
+                <Border Name="DragMeText" BorderThickness="1" BorderBrush="{StaticResource ThemeForegroundBrush}"
+                        Classes="draggable">
+                    <TextBlock Name="DragStateText" TextWrapping="Wrap">Drag Me (text)</TextBlock>
+                </Border>
+                <Border Name="DragMeFiles" BorderThickness="1" BorderBrush="{StaticResource ThemeForegroundBrush}"
+                        Classes="draggable">
+                    <TextBlock Name="DragStateFiles" TextWrapping="Wrap">Drag Me (files)</TextBlock>
+                </Border>
+                <Border Name="DragMeCustom" BorderThickness="1" BorderBrush="{StaticResource ThemeForegroundBrush}"
+                        Classes="draggable">
+                    <TextBlock Name="DragStateCustom" TextWrapping="Wrap">Drag Me (custom)</TextBlock>
+                </Border>
+            </StackPanel>
+
+            <StackPanel Margin="1"
+                        Orientation="Horizontal"
+                        Spacing="1">
+                <TextBlock Foreground="{StaticResource ThemeSelectionForegroundBrush}"
+                           Name="CopyTarget"
+                        Padding="1"
+                        Background="{StaticResource ThemeSelectionBackgroundBrush}"
+                        DragDrop.AllowDrop="True"
+                           TextWrapping="Wrap">Drop some text or files here (Copy)</TextBlock>
+                <TextBlock Name="MoveTarget" DragDrop.AllowDrop="True"
+                           Padding="1" Background="{StaticResource ThemeSelectionBackgroundBrush}"
+                           Foreground="{StaticResource ThemeSelectionForegroundBrush}"
+                           TextWrapping="Wrap">Drop some text or files here (Move)</TextBlock>
+            </StackPanel>
+        </StackPanel>
+
+        <TextBlock x:Name="DropState" TextWrapping="Wrap" />
+    </StackPanel>
+
+</UserControl>

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml
@@ -2,26 +2,41 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:console="https://github.com/jinek/consolonia"
              mc:Ignorable="d"
              x:Class="Consolonia.Gallery.Gallery.GalleryViews.GalleryDragAndDrop">
 
-    <StackPanel Orientation="Vertical" Spacing="1">
+    <StackPanel Orientation="Vertical"
+                Spacing="1">
         <TextBlock Classes="h2">Example of Drag+Drop capabilities</TextBlock>
 
         <StackPanel Orientation="Vertical">
             <StackPanel Margin="1">
-                <Border Name="DragMeText" BorderThickness="1" BorderBrush="{StaticResource ThemeForegroundBrush}"
+                <Border Name="DragMeText"
+                        BorderThickness="1"
+                        BorderBrush="{StaticResource ThemeForegroundBrush}"
                         Classes="draggable">
-                    <TextBlock Name="DragStateText" TextWrapping="Wrap">Drag Me (text)</TextBlock>
+                    <TextBlock Name="DragStateText"
+                               TextWrapping="Wrap">
+                        Drag Me (text)
+                    </TextBlock>
                 </Border>
-                <Border Name="DragMeFiles" BorderThickness="1" BorderBrush="{StaticResource ThemeForegroundBrush}"
+                <Border Name="DragMeFiles"
+                        BorderThickness="1"
+                        BorderBrush="{StaticResource ThemeForegroundBrush}"
                         Classes="draggable">
-                    <TextBlock Name="DragStateFiles" TextWrapping="Wrap">Drag Me (files)</TextBlock>
+                    <TextBlock Name="DragStateFiles"
+                               TextWrapping="Wrap">
+                        Drag Me (files)
+                    </TextBlock>
                 </Border>
-                <Border Name="DragMeCustom" BorderThickness="1" BorderBrush="{StaticResource ThemeForegroundBrush}"
+                <Border Name="DragMeCustom"
+                        BorderThickness="1"
+                        BorderBrush="{StaticResource ThemeForegroundBrush}"
                         Classes="draggable">
-                    <TextBlock Name="DragStateCustom" TextWrapping="Wrap">Drag Me (custom)</TextBlock>
+                    <TextBlock Name="DragStateCustom"
+                               TextWrapping="Wrap">
+                        Drag Me (custom)
+                    </TextBlock>
                 </Border>
             </StackPanel>
 
@@ -30,18 +45,25 @@
                         Spacing="1">
                 <TextBlock Foreground="{StaticResource ThemeSelectionForegroundBrush}"
                            Name="CopyTarget"
-                        Padding="1"
-                        Background="{StaticResource ThemeSelectionBackgroundBrush}"
-                        DragDrop.AllowDrop="True"
-                           TextWrapping="Wrap">Drop some text or files here (Copy)</TextBlock>
-                <TextBlock Name="MoveTarget" DragDrop.AllowDrop="True"
-                           Padding="1" Background="{StaticResource ThemeSelectionBackgroundBrush}"
+                           Padding="1"
+                           Background="{StaticResource ThemeSelectionBackgroundBrush}"
+                           DragDrop.AllowDrop="True"
+                           TextWrapping="Wrap">
+                    Drop some text or files here (Copy)
+                </TextBlock>
+                <TextBlock Name="MoveTarget"
+                           DragDrop.AllowDrop="True"
+                           Padding="1"
+                           Background="{StaticResource ThemeSelectionBackgroundBrush}"
                            Foreground="{StaticResource ThemeSelectionForegroundBrush}"
-                           TextWrapping="Wrap">Drop some text or files here (Move)</TextBlock>
+                           TextWrapping="Wrap">
+                    Drop some text or files here (Move)
+                </TextBlock>
             </StackPanel>
         </StackPanel>
 
-        <TextBlock x:Name="DropState" TextWrapping="Wrap" />
+        <TextBlock x:Name="DropState"
+                   TextWrapping="Wrap" />
     </StackPanel>
 
 </UserControl>

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml.cs
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using Consolonia.Core.Infrastructure;
+
+namespace Consolonia.Gallery.Gallery.GalleryViews
+{
+    public partial class GalleryDragAndDrop : UserControl
+    {
+        private readonly TextBlock _dropState;
+        private const string CustomFormat = "application/xxx-avalonia-controlcatalog-custom";
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        public GalleryDragAndDrop()
+        {
+            InitializeComponent();
+            _dropState = this.Get<TextBlock>("DropState");
+
+            int textCount = 0;
+
+            SetupDnd(
+                "Text",
+                d => d.Set(DataFormats.Text, $"Text was dragged {++textCount} times"),
+                DragDropEffects.Copy | DragDropEffects.Move | DragDropEffects.Link);
+
+            SetupDnd(
+                "Custom",
+                d => d.Set(CustomFormat, "Test123"),
+                DragDropEffects.Move);
+
+            SetupDnd(
+                "Files",
+                async d =>
+                {
+                    d.Set(DataFormats.Files, new[] { new SystemStorageFile(@"file.txt") });
+                },
+                DragDropEffects.Copy);
+        }
+
+        private void SetupDnd(string suffix, Action<DataObject> factory, DragDropEffects effects) =>
+            SetupDnd(
+                suffix,
+                o =>
+                {
+                    factory(o);
+                    return Task.CompletedTask;
+                },
+                effects);
+
+        private void SetupDnd(string suffix, Func<DataObject, Task> factory, DragDropEffects effects)
+        {
+            var dragMe = this.Get<Border>("DragMe" + suffix);
+            var dragState = this.Get<TextBlock>("DragState" + suffix);
+
+            async void DoDrag(object? sender, PointerPressedEventArgs e)
+            {
+                var dragData = new DataObject();
+                await factory(dragData);
+
+                dragState.Text = "Dragging...";
+                var result = await DragDrop.DoDragDrop(e, dragData, effects);
+                switch (result)
+                {
+                    case DragDropEffects.Move:
+                        dragState.Text = "Data was moved";
+                        break;
+                    case DragDropEffects.Copy:
+                        dragState.Text = "Data was copied";
+                        break;
+                    case DragDropEffects.Link:
+                        dragState.Text = "Data was linked";
+                        break;
+                    case DragDropEffects.None:
+                        dragState.Text = "The drag operation was canceled";
+                        break;
+                    default:
+                        dragState.Text = "Unknown result";
+                        break;
+                }
+            }
+
+            void DragOver(object? sender, DragEventArgs e)
+            {
+                if (e.Source is Control c && c.Name == "MoveTarget")
+                {
+                    e.DragEffects = e.DragEffects & (DragDropEffects.Move);
+                }
+                else
+                {
+                    e.DragEffects = e.DragEffects & (DragDropEffects.Copy);
+                }
+
+                // Only allow if the dragged data contains text or filenames.
+                if (!e.Data.Contains(DataFormats.Text)
+                    && !e.Data.Contains(DataFormats.Files)
+                    && !e.Data.Contains(CustomFormat))
+                    e.DragEffects = DragDropEffects.None;
+            }
+
+            async void Drop(object? sender, DragEventArgs e)
+            {
+                if (e.Source is Control c && c.Name == "MoveTarget")
+                {
+                    e.DragEffects = e.DragEffects & (DragDropEffects.Move);
+                }
+                else
+                {
+                    e.DragEffects = e.DragEffects & (DragDropEffects.Copy);
+                }
+
+                if (e.Data.Contains(DataFormats.Text))
+                {
+                    _dropState.Text = $"({e.DragEffects}) {e.Data.GetText()}";
+                }
+                else if (e.Data.Contains(DataFormats.Files))
+                {
+                    var files = e.Data.GetFiles() ?? Array.Empty<IStorageItem>();
+                    var contentStr = $"({e.DragEffects}) {Environment.NewLine}";
+
+                    foreach (var item in files)
+                    {
+                        if (item is IStorageFile file)
+                        {
+                            //var content = await DialogsPage.ReadTextFromFile(file, 500);
+                            contentStr += $"File {file.Name}:{Environment.NewLine}";
+                        }
+                        else if (item is IStorageFolder folder)
+                        {
+                            var childrenCount = 0;
+                            await foreach (var _ in folder.GetItemsAsync())
+                            {
+                                childrenCount++;
+                            }
+                            contentStr += $"Folder {item.Name}: items {childrenCount}{Environment.NewLine}{Environment.NewLine}";
+                        }
+                    }
+
+                    _dropState.Text = contentStr;
+                }
+#pragma warning disable CS0618 // Type or member is obsolete
+                else if (e.Data.Contains(DataFormats.FileNames))
+                {
+                    var files = e.Data.GetFileNames();
+                    _dropState.Text = $"({e.DragEffects})  {string.Join(Environment.NewLine, files ?? Array.Empty<string>())}";
+                }
+#pragma warning restore CS0618 // Type or member is obsolete
+                else if (e.Data.Contains(CustomFormat))
+                {
+                    _dropState.Text = $"({e.DragEffects})  Custom: {e.Data.Get(CustomFormat)}";
+                }
+            }
+
+            dragMe.PointerPressed += DoDrag;
+
+            AddHandler(DragDrop.DropEvent, Drop);
+            AddHandler(DragDrop.DragOverEvent, DragOver);
+        }
+
+    }
+}

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml.cs
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryDragAndDrop.axaml.cs
@@ -10,13 +10,8 @@ namespace Consolonia.Gallery.Gallery.GalleryViews
 {
     public partial class GalleryDragAndDrop : UserControl
     {
-        private readonly TextBlock _dropState;
         private const string CustomFormat = "application/xxx-avalonia-controlcatalog-custom";
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
+        private readonly TextBlock _dropState;
 
         public GalleryDragAndDrop()
         {
@@ -37,14 +32,17 @@ namespace Consolonia.Gallery.Gallery.GalleryViews
 
             SetupDnd(
                 "Files",
-                async d =>
-                {
-                    d.Set(DataFormats.Files, new[] { new SystemStorageFile(@"file.txt") });
-                },
+                async d => { d.Set(DataFormats.Files, new[] { new SystemStorageFile(@"file.txt") }); },
                 DragDropEffects.Copy);
         }
 
-        private void SetupDnd(string suffix, Action<DataObject> factory, DragDropEffects effects) =>
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        private void SetupDnd(string suffix, Action<DataObject> factory, DragDropEffects effects)
+        {
             SetupDnd(
                 suffix,
                 o =>
@@ -53,6 +51,7 @@ namespace Consolonia.Gallery.Gallery.GalleryViews
                     return Task.CompletedTask;
                 },
                 effects);
+        }
 
         private void SetupDnd(string suffix, Func<DataObject, Task> factory, DragDropEffects effects)
         {
@@ -65,7 +64,7 @@ namespace Consolonia.Gallery.Gallery.GalleryViews
                 await factory(dragData);
 
                 dragState.Text = "Dragging...";
-                var result = await DragDrop.DoDragDrop(e, dragData, effects);
+                DragDropEffects result = await DragDrop.DoDragDrop(e, dragData, effects);
                 switch (result)
                 {
                     case DragDropEffects.Move:
@@ -89,13 +88,9 @@ namespace Consolonia.Gallery.Gallery.GalleryViews
             void DragOver(object? sender, DragEventArgs e)
             {
                 if (e.Source is Control c && c.Name == "MoveTarget")
-                {
-                    e.DragEffects = e.DragEffects & (DragDropEffects.Move);
-                }
+                    e.DragEffects = e.DragEffects & DragDropEffects.Move;
                 else
-                {
-                    e.DragEffects = e.DragEffects & (DragDropEffects.Copy);
-                }
+                    e.DragEffects = e.DragEffects & DragDropEffects.Copy;
 
                 // Only allow if the dragged data contains text or filenames.
                 if (!e.Data.Contains(DataFormats.Text)
@@ -107,13 +102,9 @@ namespace Consolonia.Gallery.Gallery.GalleryViews
             async void Drop(object? sender, DragEventArgs e)
             {
                 if (e.Source is Control c && c.Name == "MoveTarget")
-                {
-                    e.DragEffects = e.DragEffects & (DragDropEffects.Move);
-                }
+                    e.DragEffects = e.DragEffects & DragDropEffects.Move;
                 else
-                {
-                    e.DragEffects = e.DragEffects & (DragDropEffects.Copy);
-                }
+                    e.DragEffects = e.DragEffects & DragDropEffects.Copy;
 
                 if (e.Data.Contains(DataFormats.Text))
                 {
@@ -122,10 +113,9 @@ namespace Consolonia.Gallery.Gallery.GalleryViews
                 else if (e.Data.Contains(DataFormats.Files))
                 {
                     var files = e.Data.GetFiles() ?? Array.Empty<IStorageItem>();
-                    var contentStr = $"({e.DragEffects}) {Environment.NewLine}";
+                    string contentStr = $"({e.DragEffects}) {Environment.NewLine}";
 
-                    foreach (var item in files)
-                    {
+                    foreach (IStorageItem item in files)
                         if (item is IStorageFile file)
                         {
                             //var content = await DialogsPage.ReadTextFromFile(file, 500);
@@ -133,14 +123,11 @@ namespace Consolonia.Gallery.Gallery.GalleryViews
                         }
                         else if (item is IStorageFolder folder)
                         {
-                            var childrenCount = 0;
-                            await foreach (var _ in folder.GetItemsAsync())
-                            {
-                                childrenCount++;
-                            }
-                            contentStr += $"Folder {item.Name}: items {childrenCount}{Environment.NewLine}{Environment.NewLine}";
+                            int childrenCount = 0;
+                            await foreach (IStorageItem _ in folder.GetItemsAsync()) childrenCount++;
+                            contentStr +=
+                                $"Folder {item.Name}: items {childrenCount}{Environment.NewLine}{Environment.NewLine}";
                         }
-                    }
 
                     _dropState.Text = contentStr;
                 }
@@ -148,7 +135,8 @@ namespace Consolonia.Gallery.Gallery.GalleryViews
                 else if (e.Data.Contains(DataFormats.FileNames))
                 {
                     var files = e.Data.GetFileNames();
-                    _dropState.Text = $"({e.DragEffects})  {string.Join(Environment.NewLine, files ?? Array.Empty<string>())}";
+                    _dropState.Text =
+                        $"({e.DragEffects})  {string.Join(Environment.NewLine, files ?? Array.Empty<string>())}";
                 }
 #pragma warning restore CS0618 // Type or member is obsolete
                 else if (e.Data.Contains(CustomFormat))
@@ -162,6 +150,5 @@ namespace Consolonia.Gallery.Gallery.GalleryViews
             AddHandler(DragDrop.DropEvent, Drop);
             AddHandler(DragDrop.DragOverEvent, DragOver);
         }
-
     }
 }

--- a/src/Consolonia.PlatformSupport/Win32Console.cs
+++ b/src/Consolonia.PlatformSupport/Win32Console.cs
@@ -283,46 +283,65 @@ namespace Consolonia.PlatformSupport
                         inputModifiers);
                     break;
 
+                case MOUSE_EVENT_FLAG.MOUSE_MOVED | MOUSE_EVENT_FLAG.DOUBLE_CLICK:
+                    // Win32 maps MOUSE_DOWN/DRAG => as MOVED|DOUBLE_CLICK 
+                    // Avalonia wants it to just be MOUSE_DOWN, and then subsequent MOUSE_MOVE events
                 case MOUSE_EVENT_FLAG.NONE:
-                    foreach (MOUSE_BUTTON_STATE flag in Enum.GetValues<MOUSE_BUTTON_STATE>())
-                        if (!_mouseButtonsState.HasFlag(flag) && mouseEvent.dwButtonState.HasFlag(flag))
-                        {
-                            // If we went from flag off to flag on
-                            RawPointerEventType buttonDownEventType =
-                                MouseButtonDownEventTypeTranslator.Translate(flag);
+                    {
+                        bool emitted = false;
+                        foreach (MOUSE_BUTTON_STATE flag in Enum.GetValues<MOUSE_BUTTON_STATE>())
+                            if (!_mouseButtonsState.HasFlag(flag) && mouseEvent.dwButtonState.HasFlag(flag))
+                            {
+                                // If we went from flag off to flag on
+                                RawPointerEventType buttonDownEventType =
+                                    MouseButtonDownEventTypeTranslator.Translate(flag);
 #pragma warning disable IDE0034
-                            // Simplify 'default' expression
-                            if (buttonDownEventType != default)
-                                RaiseMouseEvent(buttonDownEventType,
-                                    point,
-                                    null,
-                                    inputModifiers);
+                                // Simplify 'default' expression
+                                if (buttonDownEventType != default)
+                                {
+                                    RaiseMouseEvent(buttonDownEventType,
+                                        point,
+                                        null,
+                                        inputModifiers);
+                                    _mouseButtonsState = mouseEvent.dwButtonState;
+                                    emitted = true;
+                                    break;
+                                }
 #pragma warning restore IDE0034
-                            // Simplify 'default' expression
-                        }
+                                // Simplify 'default' expression
+                            }
 
-                        else if (_mouseButtonsState.HasFlag(flag) && !mouseEvent.dwButtonState.HasFlag(flag))
-                        {
-                            // If we went from flag On to flag off
-                            RawPointerEventType buttonEventType = MouseButtonUpEventTypeTranslator.Translate(flag);
+                            else if (_mouseButtonsState.HasFlag(flag) && !mouseEvent.dwButtonState.HasFlag(flag))
+                            {
+                                // If we went from flag On to flag off
+                                RawPointerEventType buttonEventType = MouseButtonUpEventTypeTranslator.Translate(flag);
 #pragma warning disable IDE0034
-                            // Simplify 'default' expression
-                            if (buttonEventType != default)
-                                RaiseMouseEvent(buttonEventType,
-                                    point,
-                                    null,
-                                    inputModifiers);
+                                // Simplify 'default' expression
+                                if (buttonEventType != default)
+                                {
+
+                                    RaiseMouseEvent(buttonEventType,
+                                        point,
+                                        null,
+                                        inputModifiers);
+                                    _mouseButtonsState = mouseEvent.dwButtonState;
+                                    emitted = true;
+                                    break;
+                                }
 #pragma warning restore IDE0034
-                            // Simplify 'default' expression
-                        }
-                        else
+                                // Simplify 'default' expression
+                            }
+
+                        if (!emitted)
                         {
+                            // If we didn't emit any button up/down transition events, emit a move event
                             RaiseMouseEvent(eventType,
                                 point,
-                                null,
+                                wheelDelta,
                                 inputModifiers);
+                            _mouseButtonsState = mouseEvent.dwButtonState;
                         }
-
+                    }
                     break;
 
                 case MOUSE_EVENT_FLAG.MOUSE_WHEELED:
@@ -341,11 +360,6 @@ namespace Consolonia.PlatformSupport
                         wheelDelta,
                         inputModifiers);
                     _mouseButtonsState = mouseEvent.dwButtonState;
-                    break;
-                case MOUSE_EVENT_FLAG.MOUSE_MOVED | MOUSE_EVENT_FLAG.DOUBLE_CLICK:
-                    RaiseMouseEvent(RawPointerEventType.LeftButtonDown, point, null, inputModifiers);
-                    RaiseMouseEvent(RawPointerEventType.Move, point, null, inputModifiers);
-                    //RaiseMouseEvent(RawPointerEventType.LeftButtonUp, point, null, inputModifiers);
                     break;
                 default:
                     throw new InvalidOperationException(mouseEvent.dwEventFlags.ToString());

--- a/src/Consolonia.PlatformSupport/Win32Console.cs
+++ b/src/Consolonia.PlatformSupport/Win32Console.cs
@@ -284,64 +284,63 @@ namespace Consolonia.PlatformSupport
                     break;
 
                 case MOUSE_EVENT_FLAG.MOUSE_MOVED | MOUSE_EVENT_FLAG.DOUBLE_CLICK:
-                    // Win32 maps MOUSE_DOWN/DRAG => as MOVED|DOUBLE_CLICK 
-                    // Avalonia wants it to just be MOUSE_DOWN, and then subsequent MOUSE_MOVE events
+                // Win32 maps MOUSE_DOWN/DRAG => as MOVED|DOUBLE_CLICK 
+                // Avalonia wants it to just be MOUSE_DOWN, and then subsequent MOUSE_MOVE events
                 case MOUSE_EVENT_FLAG.NONE:
-                    {
-                        bool emitted = false;
-                        foreach (MOUSE_BUTTON_STATE flag in Enum.GetValues<MOUSE_BUTTON_STATE>())
-                            if (!_mouseButtonsState.HasFlag(flag) && mouseEvent.dwButtonState.HasFlag(flag))
-                            {
-                                // If we went from flag off to flag on
-                                RawPointerEventType buttonDownEventType =
-                                    MouseButtonDownEventTypeTranslator.Translate(flag);
-#pragma warning disable IDE0034
-                                // Simplify 'default' expression
-                                if (buttonDownEventType != default)
-                                {
-                                    RaiseMouseEvent(buttonDownEventType,
-                                        point,
-                                        null,
-                                        inputModifiers);
-                                    _mouseButtonsState = mouseEvent.dwButtonState;
-                                    emitted = true;
-                                    break;
-                                }
-#pragma warning restore IDE0034
-                                // Simplify 'default' expression
-                            }
-
-                            else if (_mouseButtonsState.HasFlag(flag) && !mouseEvent.dwButtonState.HasFlag(flag))
-                            {
-                                // If we went from flag On to flag off
-                                RawPointerEventType buttonEventType = MouseButtonUpEventTypeTranslator.Translate(flag);
-#pragma warning disable IDE0034
-                                // Simplify 'default' expression
-                                if (buttonEventType != default)
-                                {
-
-                                    RaiseMouseEvent(buttonEventType,
-                                        point,
-                                        null,
-                                        inputModifiers);
-                                    _mouseButtonsState = mouseEvent.dwButtonState;
-                                    emitted = true;
-                                    break;
-                                }
-#pragma warning restore IDE0034
-                                // Simplify 'default' expression
-                            }
-
-                        if (!emitted)
+                {
+                    bool emitted = false;
+                    foreach (MOUSE_BUTTON_STATE flag in Enum.GetValues<MOUSE_BUTTON_STATE>())
+                        if (!_mouseButtonsState.HasFlag(flag) && mouseEvent.dwButtonState.HasFlag(flag))
                         {
-                            // If we didn't emit any button up/down transition events, emit a move event
-                            RaiseMouseEvent(eventType,
-                                point,
-                                wheelDelta,
-                                inputModifiers);
-                            _mouseButtonsState = mouseEvent.dwButtonState;
+                            // If we went from flag off to flag on
+                            RawPointerEventType buttonDownEventType =
+                                MouseButtonDownEventTypeTranslator.Translate(flag);
+#pragma warning disable IDE0034
+                            // Simplify 'default' expression
+                            if (buttonDownEventType != default)
+                            {
+                                RaiseMouseEvent(buttonDownEventType,
+                                    point,
+                                    null,
+                                    inputModifiers);
+                                _mouseButtonsState = mouseEvent.dwButtonState;
+                                emitted = true;
+                                break;
+                            }
+#pragma warning restore IDE0034
+                            // Simplify 'default' expression
                         }
+
+                        else if (_mouseButtonsState.HasFlag(flag) && !mouseEvent.dwButtonState.HasFlag(flag))
+                        {
+                            // If we went from flag On to flag off
+                            RawPointerEventType buttonEventType = MouseButtonUpEventTypeTranslator.Translate(flag);
+#pragma warning disable IDE0034
+                            // Simplify 'default' expression
+                            if (buttonEventType != default)
+                            {
+                                RaiseMouseEvent(buttonEventType,
+                                    point,
+                                    null,
+                                    inputModifiers);
+                                _mouseButtonsState = mouseEvent.dwButtonState;
+                                emitted = true;
+                                break;
+                            }
+#pragma warning restore IDE0034
+                            // Simplify 'default' expression
+                        }
+
+                    if (!emitted)
+                    {
+                        // If we didn't emit any button up/down transition events, emit a move event
+                        RaiseMouseEvent(eventType,
+                            point,
+                            wheelDelta,
+                            inputModifiers);
+                        _mouseButtonsState = mouseEvent.dwButtonState;
                     }
+                }
                     break;
 
                 case MOUSE_EVENT_FLAG.MOUSE_WHEELED:


### PR DESCRIPTION
* Win32 was not modeling click drag the way Avalonia expects. Win32 drive generates MOVE/DOUBLECLICK, which we were mapping to MOVE and UP events.  Now we map to the way that Avalonia expects, which is a MOUSE BUTTON DOWN EVENT followed by MOVE with MOUSE_BUTTON_DOWN
 
* Added gallery page for drag drop
![dragAndDrop](https://github.com/user-attachments/assets/43378d09-9d0b-4f22-9f6d-4a43e376690e)