### PR TITLE
Update Fluent button focus styling

### DIFF
--- a/src/Consolonia.Themes/Fluent/Controls/Button.axaml
+++ b/src/Consolonia.Themes/Fluent/Controls/Button.axaml
@@ -9,13 +9,7 @@
         <Setter Property="Foreground"
                 Value="{DynamicResource ThemeForegroundBrush}" />
         <Setter Property="BorderThickness"
-                Value="1" />
-        <Setter Property="BorderBrush">
-            <Setter.Value>
-                <brushes:LineBrush Brush="{DynamicResource ThemeAlternativeBackgroundBrush}"
-                                   LineStyle="Edge" />
-            </Setter.Value>
-        </Setter>
+                Value="0" />
     </Style>
 
     <Style Selector="Button[IsDefault=True]">
@@ -23,43 +17,20 @@
                 Value="{DynamicResource ThemeChooserBackgroundBrush}" />
         <Setter Property="Foreground"
                 Value="{DynamicResource ThemeChooserForegroundBrush}" />
-        <Setter Property="BorderBrush">
-            <Setter.Value>
-                <brushes:LineBrush Brush="{DynamicResource ThemeChooserBackgroundBrush}"
-                                   LineStyle="Edge" />
-            </Setter.Value>
-        </Setter>
     </Style>
 
-    <Style Selector="Button:focus">
-        <Setter Property="BorderBrush">
-            <Setter.Value>
-                <brushes:LineBrush Brush="{DynamicResource ThemeBorderBrush}"
-                                   LineStyle="Edge" />
-            </Setter.Value>
-        </Setter>
+    <Style Selector="Button:focus /template/ Panel#FocusOverlay">
+        <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <Style Selector="Button:clickdelayed">
         <Setter Property="Background"
                 Value="{DynamicResource ThemeBorderBrush}" />
-        <Setter Property="BorderBrush">
-            <Setter.Value>
-                <brushes:LineBrush Brush="Transparent"
-                                   LineStyle="Edge" />
-            </Setter.Value>
-        </Setter>
     </Style>
 
     <Style Selector="Button[IsDefault=True]:clickdelayed">
         <Setter Property="Background"
                 Value="{DynamicResource ThemeActionBackgroundBrush}" />
-        <Setter Property="BorderBrush">
-            <Setter.Value>
-                <brushes:LineBrush Brush="Transparent"
-                                   LineStyle="Edge" />
-            </Setter.Value>
-        </Setter>
     </Style>
 
 </Styles>

--- a/src/Consolonia.Themes/Templates/Controls/Button.axaml
+++ b/src/Consolonia.Themes/Templates/Controls/Button.axaml
@@ -55,6 +55,10 @@
                             </Grid>
                         </Panel>
 
+                        <Panel x:Name="FocusOverlay"
+                               Background="#80000000"
+                               IsVisible="False" />
+
                         <!--Shadows-->
 
                         <!--Shadow under-->


### PR DESCRIPTION
## Summary
- remove border-based focus cues from Fluent buttons
- add a transparent overlay panel and show it on focus

## Testing
- `dotnet test src/Consolonia.sln --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68727f0821448322a1ffef24c8991c2a