### PR TITLE
Fix ALT key processed twice

### DIFF
--- a/src/Consolonia.PlatformSupport/CursesConsole.cs
+++ b/src/Consolonia.PlatformSupport/CursesConsole.cs
@@ -288,7 +288,7 @@ namespace Consolonia.PlatformSupport
 
             // escape of ESC
             yield return new SafeLockMatcher(
-                new RegexMatcher<int>(_ => { RaiseKeyPressInternal(Key.Esc); }, ToChar, @"^\x1B+$", 2), 0, 0);
+                new RegexMatcher<int>(_ => { RaiseKeyPressInternal(Key.Esc); }, ToChar, @"^\x1B+$", 2), (int)Key.Esc, 0);
 
             // The ESC-number handling, debatable.
             yield return new SafeLockMatcher(new RegexMatcher<int>(tuple =>
@@ -341,7 +341,7 @@ namespace Consolonia.PlatformSupport
                 }
 
                 RaiseKeyPressInternal(k);
-            }, ToChar, @"^\x1B[^\x1B\[]*$", 2), 0, 0);
+            }, ToChar, @"^\x1B[^\x1B\[]*$", 2), (int)Key.Esc, 0);
 
             // alt mask
             yield return new SafeLockMatcher(new RegexMatcher<int>(tuple =>
@@ -349,7 +349,7 @@ namespace Consolonia.PlatformSupport
                 int wch = tuple.Item2[0];
                 Key k = Key.AltMask | MapCursesKey(wch);
                 RaiseKeyPressInternal(k);
-            }, ToChar, @"^\x1B[^\x00]*$", 2), 0, Curses.KEY_CODE_YES);
+            }, ToChar, @"^\x1B[^\x00]*$", 2), (int)Key.Esc, Curses.KEY_CODE_YES);
 
             // mouse and resize detection and some special processing
             yield return new SafeLockMatcher(new GenericMatcher<int>(wch =>


### PR DESCRIPTION
## Summary
- adjust `SafeLockMatcher` init keys to handle ALT sequences starting with ESC properly

## Testing
- `dotnet test src/Tests/Consolonia.Core.Tests/Consolonia.Core.Tests.csproj --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_688699ebf1148322979067deea7db80d