### PR TITLE
Fix AutoCompleteBox popup shadow

### DIFF
--- a/src/Consolonia.Themes/Templates/Controls/AutoCompleteBox.axaml
+++ b/src/Consolonia.Themes/Templates/Controls/AutoCompleteBox.axaml
@@ -34,13 +34,22 @@
                            MaxHeight="{TemplateBinding MaxDropDownHeight}"
                            IsLightDismissEnabled="True"
                            PlacementTarget="{TemplateBinding}">
-                        <ListBox Name="PART_SelectingItemsControl"
-                                 Background="{DynamicResource ThemeAlternativeBackgroundBrush}"
-                                 BorderThickness="0"
-                                 Foreground="{DynamicResource ThemeForegroundBrush}"
-                                 ItemTemplate="{TemplateBinding ItemTemplate}"
-                                 ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                                 ScrollViewer.VerticalScrollBarVisibility="Auto" />
+                        <Panel>
+                            <Border Background="{DynamicResource ThemeShadeBrush}"
+                                    Margin="2,1,0,0" />
+                            <Border BorderBrush="{DynamicResource ThemeBorderBrush}"
+                                    BorderThickness="1"
+                                    Margin="0,0,2,1"
+                                    Background="{DynamicResource ThemeAlternativeBackgroundBrush}">
+                                <ListBox Name="PART_SelectingItemsControl"
+                                         Background="{x:Null}"
+                                         BorderThickness="0"
+                                         Foreground="{DynamicResource ThemeForegroundBrush}"
+                                         ItemTemplate="{TemplateBinding ItemTemplate}"
+                                         ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                         ScrollViewer.VerticalScrollBarVisibility="Auto" />
+                            </Border>
+                        </Panel>
                     </Popup>
                 </Panel>
             </ControlTemplate>


### PR DESCRIPTION
## Summary
- update AutoCompleteBox popup template so the shade and border match other popups

## Testing
- `dotnet test src/Tests/Consolonia.Gallery.Tests/Consolonia.Gallery.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688b48e457c883229b0104e044f3ec69