### PR TITLE
Fix maximize icon for TurboVision

### DIFF
--- a/src/Consolonia.Themes/TurboVision/Controls/WindowManager.axaml
+++ b/src/Consolonia.Themes/TurboVision/Controls/WindowManager.axaml
@@ -89,10 +89,19 @@
                                                 <brushes:SymbolsControl DockPanel.Dock="Right"
                                                                         Text="]" />
                                                 <Panel>
-                                                    <Button Content="↕"
+                                                    <!-- The original maximize icon
+                                                         used a vertical arrow which
+                                                         is not available in the
+                                                         IBM code page utilised by
+                                                         Linux consoles.  Using the
+                                                         up and down triangles
+                                                         instead keeps the
+                                                         intention clear and renders
+                                                         correctly across code pages. -->
+                                                    <Button Content="{StaticResource ThemeScrollBarUpSymbol}"
                                                             IsVisible="False"
                                                             x:Name="PART_MaximizeButton" />
-                                                    <Button Content="↕"
+                                                    <Button Content="{StaticResource ThemeScrollBarDownSymbol}"
                                                             IsVisible="False"
                                                             x:Name="PART_RestoreButton" />
                                                 </Panel>


### PR DESCRIPTION
## Summary
- use `ThemeScrollBarUpSymbol` and `ThemeScrollBarDownSymbol` resources for maximize/restore buttons
  to ensure characters render on IBM code page

## Testing
- `dotnet --info`
- `dotnet test src/Consolonia.sln --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_688b489c87388322876ea25c3bb8a52c