### PR TITLE
refactor: use ControlTheme for control overrides

### DIFF
--- a/src/Consolonia.Themes/Fluent/Controls/Button.axaml
+++ b/src/Consolonia.Themes/Fluent/Controls/Button.axaml
@@ -1,43 +1,44 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type Button}"
+                      TargetType="Button">
+            <ControlTheme.BasedOn>
+                <StaticResource ResourceKey="{x:Type Button}" />
+            </ControlTheme.BasedOn>
 
-    <!--All buttons-->
-    <Style Selector="Button">
-        <Setter Property="Padding"
-                Value="1,0,1,0" />
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeAlternativeBackgroundBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeForegroundBrush}" />
-    </Style>
+            <Setter Property="Padding"
+                    Value="1,0,1,0" />
+            <Setter Property="Background"
+                    Value="{DynamicResource ThemeAlternativeBackgroundBrush}" />
+            <Setter Property="Foreground"
+                    Value="{DynamicResource ThemeForegroundBrush}" />
 
-    <!--Default button-->
-    <Style Selector="Button[IsDefault=True]">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeChooserBackgroundBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeChooserForegroundBrush}" />
-    </Style>
+            <Style Selector="^[IsDefault=True]">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeChooserBackgroundBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource ThemeChooserForegroundBrush}" />
+            </Style>
 
-    <!--Focused button-->
-    <Style Selector="Button:focus">
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeChooserForegroundBrush}" />
-    </Style>
-    <Style Selector="Button:focus /template/ Panel#InternalBorder">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeActionBackgroundBrush}" />
-    </Style>
+            <Style Selector="^:focus">
+                <Setter Property="Foreground"
+                        Value="{DynamicResource ThemeChooserForegroundBrush}" />
+            </Style>
+            <Style Selector="^:focus /template/ Panel#InternalBorder">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeActionBackgroundBrush}" />
+            </Style>
 
-    <!--Clicked buttons-->
-    <Style Selector="Button:clickdelayed /template/ Panel#InternalBorder">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeSelectionForegroundBrush}" />
-    </Style>
-
-    <Style Selector="Button[IsDefault=True]:clickdelayed /template/ Panel#InternalBorder">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeSelectionForegroundBrush}" />
-    </Style>
-
+            <Style Selector="^:clickdelayed /template/ Panel#InternalBorder">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeSelectionForegroundBrush}" />
+            </Style>
+            <Style Selector="^[IsDefault=True]:clickdelayed /template/ Panel#InternalBorder">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeSelectionForegroundBrush}" />
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+

--- a/src/Consolonia.Themes/Fluent/Controls/ComboBox.axaml
+++ b/src/Consolonia.Themes/Fluent/Controls/ComboBox.axaml
@@ -1,11 +1,19 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type ComboBox}"
+                      TargetType="ComboBox">
+            <ControlTheme.BasedOn>
+                <StaticResource ResourceKey="{x:Type ComboBox}" />
+            </ControlTheme.BasedOn>
 
-    <!--todo: Rather than doing Style+selector, should be ControlTheme based on default ControlTheme - see button in TurboVision-->
-    <Style Selector="ComboBox /template/ ToggleButton#toggle">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeSelectionBackgroundBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeSelectionForegroundBrush}" />
-    </Style>
+            <Style Selector="^ /template/ ToggleButton#toggle">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeSelectionBackgroundBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource ThemeSelectionForegroundBrush}" />
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+

--- a/src/Consolonia.Themes/Fluent/Controls/ComboBoxItem.axaml
+++ b/src/Consolonia.Themes/Fluent/Controls/ComboBoxItem.axaml
@@ -1,8 +1,18 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="https://github.com/jinek/consolonia">
-    <Style Selector="ComboBoxItem /template/ controls|CaretControl#FocusControl">
-        <Setter Property="CaretStyle"
-                Value="None" />
-    </Style>
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type ComboBoxItem}"
+                      TargetType="ComboBoxItem">
+            <ControlTheme.BasedOn>
+                <StaticResource ResourceKey="{x:Type ComboBoxItem}" />
+            </ControlTheme.BasedOn>
+
+            <Style Selector="^ /template/ controls|CaretControl#FocusControl">
+                <Setter Property="CaretStyle"
+                        Value="None" />
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+

--- a/src/Consolonia.Themes/Fluent/Controls/ConsoloniaAccessRun.axaml
+++ b/src/Consolonia.Themes/Fluent/Controls/ConsoloniaAccessRun.axaml
@@ -1,10 +1,14 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:Consolonia.Core.Controls;assembly=Consolonia.Core">
-
-    <Style Selector="controls|ConsoloniaAccessRun:showaccesskey">
-        <Setter Property="TextDecorations"
-                Value="Underline" />
-
-    </Style>
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type controls:ConsoloniaAccessRun}"
+                      TargetType="controls:ConsoloniaAccessRun">
+            <Style Selector="^:showaccesskey">
+                <Setter Property="TextDecorations"
+                        Value="Underline" />
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+

--- a/src/Consolonia.Themes/Fluent/Controls/DataGridRow.axaml
+++ b/src/Consolonia.Themes/Fluent/Controls/DataGridRow.axaml
@@ -1,8 +1,18 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="https://github.com/jinek/consolonia">
-    <Style Selector="DataGridRow /template/ controls|CaretControl#FocusControl">
-        <Setter Property="CaretStyle"
-                Value="None" />
-    </Style>
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type DataGridRow}"
+                      TargetType="DataGridRow">
+            <ControlTheme.BasedOn>
+                <StaticResource ResourceKey="{x:Type DataGridRow}" />
+            </ControlTheme.BasedOn>
+
+            <Style Selector="^ /template/ controls|CaretControl#FocusControl">
+                <Setter Property="CaretStyle"
+                        Value="None" />
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+

--- a/src/Consolonia.Themes/Fluent/Controls/DropDownButton.axaml
+++ b/src/Consolonia.Themes/Fluent/Controls/DropDownButton.axaml
@@ -1,45 +1,53 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:brushes="https://github.com/jinek/consolonia">
-    <Style Selector="DropDownButton">
-        <Setter Property="Padding"
-                Value="1,0" />
-        <Setter Property="BorderThickness"
-                Value="1" />
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeAlternativeBackgroundBrush}" />
-        <Setter Property="BorderBrush">
-            <Setter.Value>
-                <brushes:LineBrush Brush="{DynamicResource ThemeAlternativeBackgroundBrush}"
-                                   LineStyle="Edge" />
-            </Setter.Value>
-        </Setter>
-    </Style>
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type DropDownButton}"
+                      TargetType="DropDownButton">
+            <ControlTheme.BasedOn>
+                <StaticResource ResourceKey="{x:Type DropDownButton}" />
+            </ControlTheme.BasedOn>
 
-    <Style Selector="DropDownButton /template/ brushes|SymbolsControl#DropDownGlyph">
-        <Setter Property="Margin"
-                Value="1,0,0,0" />
-    </Style>
+            <Setter Property="Padding"
+                    Value="1,0" />
+            <Setter Property="BorderThickness"
+                    Value="1" />
+            <Setter Property="Background"
+                    Value="{DynamicResource ThemeAlternativeBackgroundBrush}" />
+            <Setter Property="BorderBrush">
+                <Setter.Value>
+                    <brushes:LineBrush Brush="{DynamicResource ThemeAlternativeBackgroundBrush}"
+                                       LineStyle="Edge" />
+                </Setter.Value>
+            </Setter>
 
-    <Style Selector="DropDownButton:pressed">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeBorderBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeForegroundBrush}" />
-        <Setter Property="BorderBrush">
-            <Setter.Value>
-                <brushes:LineBrush Brush="Transparent"
-                                   LineStyle="Edge" />
-            </Setter.Value>
-        </Setter>
-    </Style>
+            <Style Selector="^ /template/ brushes|SymbolsControl#DropDownGlyph">
+                <Setter Property="Margin"
+                        Value="1,0,0,0" />
+            </Style>
 
-    <Style Selector="DropDownButton:focus">
-        <Setter Property="BorderBrush">
-            <Setter.Value>
-                <brushes:LineBrush Brush="{DynamicResource ThemeBorderBrush}"
-                                   LineStyle="Edge" />
-            </Setter.Value>
-        </Setter>
-    </Style>
+            <Style Selector="^:pressed">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeBorderBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource ThemeForegroundBrush}" />
+                <Setter Property="BorderBrush">
+                    <Setter.Value>
+                        <brushes:LineBrush Brush="Transparent"
+                                           LineStyle="Edge" />
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style Selector="^:focus">
+                <Setter Property="BorderBrush">
+                    <Setter.Value>
+                        <brushes:LineBrush Brush="{DynamicResource ThemeBorderBrush}"
+                                           LineStyle="Edge" />
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+

--- a/src/Consolonia.Themes/Fluent/Controls/ListBoxItem.axaml
+++ b/src/Consolonia.Themes/Fluent/Controls/ListBoxItem.axaml
@@ -1,8 +1,18 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="https://github.com/jinek/consolonia">
-    <Style Selector="ListBoxItem /template/ controls|CaretControl#FocusControl">
-        <Setter Property="CaretStyle"
-                Value="None" />
-    </Style>
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type ListBoxItem}"
+                      TargetType="ListBoxItem">
+            <ControlTheme.BasedOn>
+                <StaticResource ResourceKey="{x:Type ListBoxItem}" />
+            </ControlTheme.BasedOn>
+
+            <Style Selector="^ /template/ controls|CaretControl#FocusControl">
+                <Setter Property="CaretStyle"
+                        Value="None" />
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+

--- a/src/Consolonia.Themes/Fluent/Controls/TextBox.axaml
+++ b/src/Consolonia.Themes/Fluent/Controls/TextBox.axaml
@@ -1,7 +1,15 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Style Selector="TextBox">
-        <Setter Property="SelectionForegroundBrush"
-                Value="{DynamicResource ThemeChooserForegroundBrush}" />
-    </Style>
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type TextBox}"
+                      TargetType="TextBox">
+            <ControlTheme.BasedOn>
+                <StaticResource ResourceKey="{x:Type TextBox}" />
+            </ControlTheme.BasedOn>
+
+            <Setter Property="SelectionForegroundBrush"
+                    Value="{DynamicResource ThemeChooserForegroundBrush}" />
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+

--- a/src/Consolonia.Themes/Fluent/Controls/ToggleButton.axaml
+++ b/src/Consolonia.Themes/Fluent/Controls/ToggleButton.axaml
@@ -1,36 +1,43 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Style Selector="ToggleButton">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeAlternativeBackgroundBrush}" />
-    </Style>
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type ToggleButton}"
+                      TargetType="ToggleButton">
+            <ControlTheme.BasedOn>
+                <StaticResource ResourceKey="{x:Type ToggleButton}" />
+            </ControlTheme.BasedOn>
 
-    <Style Selector="ToggleButton:checked">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeChooserBackgroundBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeChooserForegroundBrush}" />
-    </Style>
+            <Setter Property="Background"
+                    Value="{DynamicResource ThemeAlternativeBackgroundBrush}" />
 
-    <Style Selector="ToggleButton:pressed">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeBorderBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeForegroundBrush}" />
-    </Style>
+            <Style Selector="^:checked">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeChooserBackgroundBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource ThemeChooserForegroundBrush}" />
+            </Style>
 
-    <Style Selector="ToggleButton:focus">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeActionBackgroundBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeForegroundBrush}" />
-    </Style>
+            <Style Selector="^:pressed">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeBorderBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource ThemeForegroundBrush}" />
+            </Style>
 
-    <Style Selector="ToggleButton:focus:checked">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeActionBackgroundBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeChooserForegroundBrush}" />
-    </Style>
+            <Style Selector="^:focus">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeActionBackgroundBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource ThemeForegroundBrush}" />
+            </Style>
 
+            <Style Selector="^:focus:checked">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeActionBackgroundBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource ThemeChooserForegroundBrush}" />
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+

--- a/src/Consolonia.Themes/TurboVision/Controls/ComboBox.axaml
+++ b/src/Consolonia.Themes/TurboVision/Controls/ComboBox.axaml
@@ -1,15 +1,24 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Style Selector="ComboBox /template/ ToggleButton#toggle">
-        <Setter Property="Background"
-                Value="{x:Null}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeForegroundBrush}" />
-    </Style>
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type ComboBox}"
+                      TargetType="ComboBox">
+            <ControlTheme.BasedOn>
+                <StaticResource ResourceKey="{x:Type ComboBox}" />
+            </ControlTheme.BasedOn>
 
-    <Style Selector="ComboBox /template/ ToggleButton#toggle /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Margin"
-                Value="0,0" />
-    </Style>
+            <Style Selector="^ /template/ ToggleButton#toggle">
+                <Setter Property="Background"
+                        Value="{x:Null}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource ThemeForegroundBrush}" />
+            </Style>
 
+            <Style Selector="^ /template/ ToggleButton#toggle /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Margin"
+                        Value="0,0" />
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+

--- a/src/Consolonia.Themes/TurboVision/Controls/DropDownButton.axaml
+++ b/src/Consolonia.Themes/TurboVision/Controls/DropDownButton.axaml
@@ -1,42 +1,49 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="https://github.com/jinek/consolonia">
-    <Style Selector="DropDownButton">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeChooserBackgroundBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeSelectionForegroundBrush}" />
-    </Style>
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type DropDownButton}"
+                      TargetType="DropDownButton">
+            <ControlTheme.BasedOn>
+                <StaticResource ResourceKey="{x:Type DropDownButton}" />
+            </ControlTheme.BasedOn>
 
-    <Style Selector="DropDownButton /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Margin"
-                Value="2,0,1,0" />
-    </Style>
-    <Style Selector="DropDownButton /template/ controls|SymbolsControl#DropDownGlyph">
-        <Setter Property="Margin"
-                Value="0,0,1,0" />
-    </Style>
+            <Setter Property="Background"
+                    Value="{DynamicResource ThemeChooserBackgroundBrush}" />
+            <Setter Property="Foreground"
+                    Value="{DynamicResource ThemeSelectionForegroundBrush}" />
 
-    <Style Selector="DropDownButton:focus /template/ controls|SymbolsControl#Part_LeftBracket">
-        <Setter Property="IsVisible"
-                Value="True" />
-    </Style>
+            <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Margin"
+                        Value="2,0,1,0" />
+            </Style>
+            <Style Selector="^ /template/ controls|SymbolsControl#DropDownGlyph">
+                <Setter Property="Margin"
+                        Value="0,0,1,0" />
+            </Style>
 
-    <Style Selector="DropDownButton:focus /template/ controls|SymbolsControl#Part_RightBracket">
-        <Setter Property="IsVisible"
-                Value="True" />
-    </Style>
-    <Style Selector="DropDownButton:focus /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Margin"
-                Value="1,0,1,0" />
-    </Style>
-    <Style Selector="DropDownButton:focus /template/ controls|SymbolsControl#DropDownGlyph">
-        <Setter Property="Margin"
-                Value="0,0,0,0" />
-    </Style>
+            <Style Selector="^:focus /template/ controls|SymbolsControl#Part_LeftBracket">
+                <Setter Property="IsVisible"
+                        Value="True" />
+            </Style>
+            <Style Selector="^:focus /template/ controls|SymbolsControl#Part_RightBracket">
+                <Setter Property="IsVisible"
+                        Value="True" />
+            </Style>
+            <Style Selector="^:focus /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Margin"
+                        Value="1,0,1,0" />
+            </Style>
+            <Style Selector="^:focus /template/ controls|SymbolsControl#DropDownGlyph">
+                <Setter Property="Margin"
+                        Value="0,0,0,0" />
+            </Style>
 
-    <Style Selector="DropDownButton:pressed">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeChooserBackgroundBrush}" />
-    </Style>
+            <Style Selector="^:pressed">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeChooserBackgroundBrush}" />
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+

--- a/src/Consolonia.Themes/TurboVision/Controls/ToggleButton.axaml
+++ b/src/Consolonia.Themes/TurboVision/Controls/ToggleButton.axaml
@@ -1,38 +1,47 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="https://github.com/jinek/consolonia">
-    <Style Selector="ToggleButton">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeChooserBackgroundBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeSelectionForegroundBrush}" />
-    </Style>
-    <Style Selector="ToggleButton:checked">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeActionBackgroundBrush}" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource ThemeSelectionForegroundBrush}" />
-    </Style>
-    <Style Selector="ToggleButton /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Margin"
-                Value="1,0" />
-    </Style>
-    <Style Selector="ToggleButton:focus /template/ controls|SymbolsControl#Part_LeftBracket">
-        <Setter Property="IsVisible"
-                Value="True" />
-    </Style>
+    <Styles.Resources>
+        <ControlTheme x:Key="{x:Type ToggleButton}"
+                      TargetType="ToggleButton">
+            <ControlTheme.BasedOn>
+                <StaticResource ResourceKey="{x:Type ToggleButton}" />
+            </ControlTheme.BasedOn>
 
-    <Style Selector="ToggleButton:focus /template/ controls|SymbolsControl#Part_RightBracket">
-        <Setter Property="IsVisible"
-                Value="True" />
-    </Style>
-    <Style Selector="ToggleButton:focus /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Margin"
-                Value="0,0" />
-    </Style>
+            <Setter Property="Background"
+                    Value="{DynamicResource ThemeChooserBackgroundBrush}" />
+            <Setter Property="Foreground"
+                    Value="{DynamicResource ThemeSelectionForegroundBrush}" />
 
-    <Style Selector="ToggleButton:pressed">
-        <Setter Property="Background"
-                Value="{DynamicResource ThemeChooserBackgroundBrush}" />
-    </Style>
+            <Style Selector="^:checked">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeActionBackgroundBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource ThemeSelectionForegroundBrush}" />
+            </Style>
+
+            <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Margin"
+                        Value="1,0" />
+            </Style>
+            <Style Selector="^:focus /template/ controls|SymbolsControl#Part_LeftBracket">
+                <Setter Property="IsVisible"
+                        Value="True" />
+            </Style>
+            <Style Selector="^:focus /template/ controls|SymbolsControl#Part_RightBracket">
+                <Setter Property="IsVisible"
+                        Value="True" />
+            </Style>
+            <Style Selector="^:focus /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Margin"
+                        Value="0,0" />
+            </Style>
+
+            <Style Selector="^:pressed">
+                <Setter Property="Background"
+                        Value="{DynamicResource ThemeChooserBackgroundBrush}" />
+            </Style>
+        </ControlTheme>
+    </Styles.Resources>
 </Styles>
+


### PR DESCRIPTION
## Summary
- use ControlTheme for Fluent button, toggle button, drop down button, combo box and related items
- mirror ControlTheme usage in TurboVision controls

## Testing
- `dotnet test src/Consolonia.sln`


------
https://chatgpt.com/codex/tasks/task_e_688f10ebaafc8322b841e34f9476b154