### PR TITLE
Implement immutable LineBrush and MoveConsoleCaretToPositionBrush

### DIFF
--- a/src/Consolonia.Controls/Brushes/LineBrush.cs
+++ b/src/Consolonia.Controls/Brushes/LineBrush.cs
@@ -10,7 +10,6 @@ namespace Consolonia.Controls.Brushes
     /// </summary>
     public class LineBrush : Animatable, IImmutableBrush
     {
-        //todo: we don't really implement immutable brush
         public static readonly StyledProperty<IBrush> BrushProperty =
             AvaloniaProperty.Register<LineBrush, IBrush>(
                 ControlUtils.GetStyledPropertyName() /*todo: re-use this method everywhere*/);
@@ -30,9 +29,38 @@ namespace Consolonia.Controls.Brushes
             set => SetValue(LineStyleProperty, value);
         }
 
-        //todo: how did it work without following 3 items? How should it work now, check avalonia. Search for B75ABC91-2CDD-4557-9201-16AC483C8D7B
-        public double Opacity => 1;
-        public ITransform Transform => null;
-        public RelativePoint TransformOrigin => RelativePoint.TopLeft;
+        /// <inheritdoc />
+        public double Opacity => Brush?.Opacity ?? 1;
+
+        /// <inheritdoc />
+        public ITransform Transform => Brush?.Transform;
+
+        /// <inheritdoc />
+        public RelativePoint TransformOrigin => Brush?.TransformOrigin ?? RelativePoint.TopLeft;
+
+        /// <summary>
+        ///     Creates an immutable snapshot of this brush.
+        /// </summary>
+        public IImmutableBrush ToImmutable()
+        {
+            return new ImmutableLineBrush(Brush?.ToImmutable(),
+                new LineStyles(LineStyle.Left, LineStyle.Top, LineStyle.Right, LineStyle.Bottom));
+        }
+
+        private sealed class ImmutableLineBrush : IImmutableBrush
+        {
+            public ImmutableLineBrush(IImmutableBrush brush, LineStyles lineStyle)
+            {
+                Brush = brush;
+                LineStyle = lineStyle;
+            }
+
+            public IImmutableBrush Brush { get; }
+            public LineStyles LineStyle { get; }
+
+            public double Opacity => Brush?.Opacity ?? 1;
+            public ITransform Transform => Brush?.Transform;
+            public RelativePoint TransformOrigin => Brush?.TransformOrigin ?? RelativePoint.TopLeft;
+        }
     }
 }

--- a/src/Consolonia.Controls/Brushes/MoveConsoleCaretToPositionBrush.cs
+++ b/src/Consolonia.Controls/Brushes/MoveConsoleCaretToPositionBrush.cs
@@ -21,9 +21,31 @@ namespace Consolonia.Controls.Brushes
             set => SetValue(CaretStyleProperty, value);
         }
 
-        //todo: Search for B75ABC91-2CDD-4557-9201-16AC483C8D7B
+        // TODO B75ABC91-2CDD-4557-9201-16AC483C8D7B implement drawing with opacity and transform
         public double Opacity => 1;
         public ITransform Transform => null;
         public RelativePoint TransformOrigin => RelativePoint.TopLeft;
+
+        /// <summary>
+        ///     Creates an immutable snapshot of this brush.
+        /// </summary>
+        public IImmutableBrush ToImmutable()
+        {
+            return new ImmutableMoveConsoleCaretToPositionBrush(CaretStyle);
+        }
+
+        private sealed class ImmutableMoveConsoleCaretToPositionBrush : IImmutableBrush
+        {
+            public ImmutableMoveConsoleCaretToPositionBrush(CaretStyle caretStyle)
+            {
+                CaretStyle = caretStyle;
+            }
+
+            public CaretStyle CaretStyle { get; }
+
+            public double Opacity => 1;
+            public ITransform Transform => null;
+            public RelativePoint TransformOrigin => RelativePoint.TopLeft;
+        }
     }
 }

--- a/src/Tests/Consolonia.Core.Tests/WithLifetimeFixture/LineBrushTests.cs
+++ b/src/Tests/Consolonia.Core.Tests/WithLifetimeFixture/LineBrushTests.cs
@@ -1,0 +1,30 @@
+using Avalonia.Media;
+using Consolonia.Controls.Brushes;
+using NUnit.Framework;
+
+namespace Consolonia.Core.Tests.WithLifetimeFixture
+{
+    [TestFixture]
+    public class LineBrushTests
+    {
+        [Test]
+        public void ToImmutablePreservesInnerBrushAndStyle()
+        {
+            var lineBrush = new LineBrush { Brush = Brushes.Red, LineStyle = LineStyle.DoubleLine };
+            var immutable = lineBrush.ToImmutable();
+
+            Assert.That(immutable, Is.Not.Null);
+
+            var innerBrushProp = immutable.GetType().GetProperty("Brush");
+            Assert.That(innerBrushProp, Is.Not.Null);
+            var innerBrush = innerBrushProp.GetValue(immutable) as ISolidColorBrush;
+            Assert.That(innerBrush, Is.Not.Null);
+            Assert.That(innerBrush.Color, Is.EqualTo(Colors.Red));
+
+            var styleProp = immutable.GetType().GetProperty("LineStyle");
+            Assert.That(styleProp, Is.Not.Null);
+            var lineStyles = (LineStyles)styleProp.GetValue(immutable);
+            Assert.That(lineStyles.Left, Is.EqualTo(LineStyle.DoubleLine));
+        }
+    }
+}

--- a/src/Tests/Consolonia.Core.Tests/WithLifetimeFixture/MoveConsoleCaretToPositionBrushTests.cs
+++ b/src/Tests/Consolonia.Core.Tests/WithLifetimeFixture/MoveConsoleCaretToPositionBrushTests.cs
@@ -1,0 +1,24 @@
+using Consolonia.Controls;
+using Consolonia.Controls.Brushes;
+using NUnit.Framework;
+
+namespace Consolonia.Core.Tests.WithLifetimeFixture
+{
+    [TestFixture]
+    public class MoveConsoleCaretToPositionBrushTests
+    {
+        [Test]
+        public void ToImmutablePreservesCaretStyle()
+        {
+            var brush = new MoveConsoleCaretToPositionBrush { CaretStyle = CaretStyle.SteadyUnderline };
+            var immutable = brush.ToImmutable();
+
+            Assert.That(immutable, Is.Not.Null);
+
+            var styleProp = immutable.GetType().GetProperty("CaretStyle");
+            Assert.That(styleProp, Is.Not.Null);
+            var style = (CaretStyle)styleProp.GetValue(immutable);
+            Assert.That(style, Is.EqualTo(CaretStyle.SteadyUnderline));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make LineBrush delegate brush properties and provide ToImmutable()
- cover LineBrush.ToImmutable with unit test
- add ToImmutable to MoveConsoleCaretToPositionBrush and replace TODO with guideline comment
- cover MoveConsoleCaretToPositionBrush.ToImmutable with unit test

## Testing
- `dotnet test src/Tests/Consolonia.Core.Tests/Consolonia.Core.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6893fc8b6438832290d43dbb95c65d6f