### PR TITLE
Move gallery controls to menu

### DIFF
--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryLabel.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryLabel.axaml
@@ -19,7 +19,7 @@
         <Label Target="FirstNameEdit"
                Grid.Row="1"
                Grid.Column="0">
-            _First name
+            First _name
         </Label>
         <TextBox Name="FirstNameEdit"
                  Grid.Column="2"

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryLabel.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryLabel.axaml
@@ -12,7 +12,7 @@
           RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,*">
         <TextBlock Grid.Row="0"
                    Grid.ColumnSpan="3"
-                   Text="Press ALT+F, ALT+L, ALT+B to focus on a field. Or use arrow keys to jump between fields with XYFocus"
+                   Text="Press ALT+N, ALT+L, ALT+B to focus on a field. Or use arrow keys to jump between fields using XYFocus"
                    Margin="0,0,0,1"
                    TextWrapping="Wrap"
                    Foreground="{DynamicResource ThemeNoDisturbBrush}" />

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml
@@ -10,59 +10,38 @@
         <DockPanel.Resources>
             <gallery:GalleryItemConverter x:Key="GalleryItemConverter" />
         </DockPanel.Resources>
-        <Grid RowDefinitions="* Auto"
-              DockPanel.Dock="Left">
-            <DataGrid x:Name="GalleryGrid"
-                      Grid.Row="0"
-                      SelectedIndex="0"
-                      SelectionMode="Single">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="Name"
-                                        Binding="{Binding Name}" />
-                </DataGrid.Columns>
-            </DataGrid>
-            <Grid Grid.Row="1"
-                  RowDefinitions="Auto Auto"
-                  ColumnDefinitions="Auto *"
-                  Margin="0 0 0 1">
-                <Label Content="_Theme" />
-                <ComboBox Grid.Column="1"
-                          x:Name="ThemeCombo"
-                          SelectionChanged="ComboBox_SelectionChanged"
-                          IsTabStop="false"
-                          SelectedIndex="0"
-                          HorizontalContentAlignment="Stretch">
-                    <ComboBoxItem Content="Modern" />
-                    <ComboBoxItem Content="TurboVision" />
-                </ComboBox>
-            </Grid>
 
-        </Grid>
-        <Grid RowDefinitions="* Auto">
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_File">
+                <MenuItem Header="_Show XAML" Click="OnShowXaml" />
+                <MenuItem Header="Show _Code Behind" Click="OnShowCodeBehind" />
+                <MenuItem Header="E_xit" Click="Exit_Click" />
+            </MenuItem>
+            <MenuItem Header="_Theme">
+                <MenuItem x:Name="ThemeModernMenuItem"
+                          Header="_Modern"
+                          Tag="Modern"
+                          Click="OnThemeMenuItemClick" />
+                <MenuItem x:Name="ThemeTurboVisionMenuItem"
+                          Header="_TurboVision"
+                          Tag="TurboVision"
+                          Click="OnThemeMenuItemClick" />
+            </MenuItem>
+        </Menu>
 
-            <Border
-                Child="{Binding ElementName=GalleryGrid,Path=SelectedItem, Converter={StaticResource GalleryItemConverter}}"
-                BorderThickness="1"
-                BorderBrush="{DynamicResource ThemeBorderBrush}" />
-            <StackPanel Orientation="Horizontal"
-                        HorizontalAlignment="Right"
-                        Spacing="1"
-                        Grid.Row="1">
-                <Button Click="OnShowXaml"
-                        IsTabStop="False"
-                        HorizontalAlignment="Right">
-                    _Show XAML
-                </Button>
-                <Button Click="OnShowCodeBehind"
-                        IsTabStop="False"
-                        HorizontalAlignment="Right">
-                    Show _Code Behind
-                </Button>
-                <Button Click="Exit_Click"
-                        IsTabStop="False">
-                    E_xit
-                </Button>
-            </StackPanel>
-        </Grid>
+        <DataGrid x:Name="GalleryGrid"
+                  DockPanel.Dock="Left"
+                  SelectedIndex="0"
+                  SelectionMode="Single">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Name"
+                                    Binding="{Binding Name}" />
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <Border
+            Child="{Binding ElementName=GalleryGrid,Path=SelectedItem, Converter={StaticResource GalleryItemConverter}}"
+            BorderThickness="1"
+            BorderBrush="{DynamicResource ThemeBorderBrush}" />
     </DockPanel>
 </Window>

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml
@@ -13,9 +13,12 @@
 
         <Menu DockPanel.Dock="Top">
             <MenuItem Header="_File">
-                <MenuItem Header="_Show XAML" Click="OnShowXaml" />
-                <MenuItem Header="Show _Code Behind" Click="OnShowCodeBehind" />
-                <MenuItem Header="E_xit" Click="Exit_Click" />
+                <MenuItem Header="_Show XAML"
+                          Click="OnShowXaml" />
+                <MenuItem Header="Show _Code Behind"
+                          Click="OnShowCodeBehind" />
+                <MenuItem Header="E_xit"
+                          Click="Exit_Click" />
             </MenuItem>
             <MenuItem Header="_Theme">
                 <MenuItem x:Name="ThemeModernMenuItem"

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml
@@ -6,7 +6,7 @@
         mc:Ignorable="d"
         x:Class="Consolonia.Gallery.View.ControlsListView">
 
-    <DockPanel>
+    <DockPanel x:Name="Root">
         <DockPanel.Resources>
             <gallery:GalleryItemConverter x:Key="GalleryItemConverter" />
         </DockPanel.Resources>
@@ -21,6 +21,19 @@
                           Click="Exit_Click" />
             </MenuItem>
             <MenuItem Header="_Theme">
+                <MenuItem.Styles>
+                    <Style Selector="MenuItem">
+                        <Setter Property="Icon">
+                            <Setter.Value>
+                                <Template>
+                                    <CheckBox BorderThickness="0"
+                                              IsHitTestVisible="False"
+                                              IsChecked="{Binding $parent[MenuItem].IsChecked}" />
+                                </Template>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </MenuItem.Styles>
                 <MenuItem x:Name="ThemeModernMenuItem"
                           Header="_Modern"
                           Tag="Modern"

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml
@@ -6,21 +6,17 @@
         mc:Ignorable="d"
         x:Class="Consolonia.Gallery.View.ControlsListView">
 
-    <DockPanel x:Name="Root">
+    <DockPanel>
         <DockPanel.Resources>
             <gallery:GalleryItemConverter x:Key="GalleryItemConverter" />
         </DockPanel.Resources>
 
-        <Menu DockPanel.Dock="Top">
-            <MenuItem Header="_File">
-                <MenuItem Header="_Show XAML"
-                          Click="OnShowXaml" />
-                <MenuItem Header="Show _Code Behind"
-                          Click="OnShowCodeBehind" />
+        <Menu DockPanel.Dock="Top" IsTabStop="False">
+            <MenuItem Header="_File" IsTabStop="False">
                 <MenuItem Header="E_xit"
                           Click="Exit_Click" />
             </MenuItem>
-            <MenuItem Header="_Theme">
+            <MenuItem Header="_Theme" IsTabStop="False">
                 <MenuItem.Styles>
                     <Style Selector="MenuItem">
                         <Setter Property="Icon">
@@ -42,6 +38,12 @@
                           Header="_TurboVision"
                           Tag="TurboVision"
                           Click="OnThemeMenuItemClick" />
+            </MenuItem>
+            <MenuItem Header="_View" IsTabStop="False">
+                <MenuItem Header="Show _XAML"
+                          Click="OnShowXaml" />
+                <MenuItem Header="Show _Code Behind"
+                          Click="OnShowCodeBehind" />
             </MenuItem>
         </Menu>
 

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml
@@ -11,12 +11,15 @@
             <gallery:GalleryItemConverter x:Key="GalleryItemConverter" />
         </DockPanel.Resources>
 
-        <Menu DockPanel.Dock="Top" IsTabStop="False">
-            <MenuItem Header="_File" IsTabStop="False">
+        <Menu DockPanel.Dock="Top"
+              IsTabStop="False">
+            <MenuItem Header="_File"
+                      IsTabStop="False">
                 <MenuItem Header="E_xit"
                           Click="Exit_Click" />
             </MenuItem>
-            <MenuItem Header="_Theme" IsTabStop="False">
+            <MenuItem Header="_Theme"
+                      IsTabStop="False">
                 <MenuItem.Styles>
                     <Style Selector="MenuItem">
                         <Setter Property="Icon">
@@ -39,7 +42,8 @@
                           Tag="TurboVision"
                           Click="OnThemeMenuItemClick" />
             </MenuItem>
-            <MenuItem Header="_View" IsTabStop="False">
+            <MenuItem Header="_View"
+                      IsTabStop="False">
                 <MenuItem Header="Show _XAML"
                           Click="OnShowXaml" />
                 <MenuItem Header="Show _Code Behind"

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
@@ -127,10 +127,10 @@ namespace Consolonia.Gallery.View
                 ThemesList.TurboVision => new TurboVisionTheme(),
                 _ => throw new InvalidDataException("Unknown theme name")
             };
-
+            
             UpdateThemeMenuItems();
         }
-
+        
         private void OnLoaded(object? sender, RoutedEventArgs routedEventArgs)
         {
             UpdateThemeMenuItems();

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
@@ -115,7 +115,7 @@ namespace Consolonia.Gallery.View
         }
 
 
-        private void OnThemeMenuItemClick(object? sender, RoutedEventArgs e)
+        private void OnThemeMenuItemClick(object sender, RoutedEventArgs e)
         {
             if (sender is not MenuItem { Tag: string themeName } ||
                 !Enum.TryParse(themeName, out ThemesList selectedTheme))
@@ -129,9 +129,10 @@ namespace Consolonia.Gallery.View
             };
 
             UpdateThemeMenuItems();
+            GalleryGrid.Focus();
         }
 
-        private void OnLoaded(object? sender, RoutedEventArgs routedEventArgs)
+        private void OnLoaded(object sender, RoutedEventArgs routedEventArgs)
         {
             UpdateThemeMenuItems();
         }

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
@@ -115,10 +115,9 @@ namespace Consolonia.Gallery.View
         }
 
 
-        private void ComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private void OnThemeMenuItemClick(object? sender, RoutedEventArgs e)
         {
-            if (ThemeCombo?.SelectedItem is not ComboBoxItem selectedItem ||
-                selectedItem.Content is not string themeName ||
+            if (sender is not MenuItem { Tag: string themeName } ||
                 !Enum.TryParse(themeName, out ThemesList selectedTheme))
                 return;
 
@@ -128,12 +127,20 @@ namespace Consolonia.Gallery.View
                 ThemesList.TurboVision => new TurboVisionTheme(),
                 _ => throw new InvalidDataException("Unknown theme name")
             };
+
+            UpdateThemeMenuItems();
         }
 
-        private void OnLoaded(object sender, RoutedEventArgs routedEventArgs)
+        private void OnLoaded(object? sender, RoutedEventArgs routedEventArgs)
+        {
+            UpdateThemeMenuItems();
+        }
+
+        private void UpdateThemeMenuItems()
         {
             string themeName = Application.Current.Styles[0].GetType().Name[..^5];
-            ThemeCombo.SelectedIndex = (int)Enum.Parse<ThemesList>(themeName);
+            ThemeModernMenuItem.IsChecked = themeName == nameof(ThemesList.Modern);
+            ThemeTurboVisionMenuItem.IsChecked = themeName == nameof(ThemesList.TurboVision);
         }
     }
 

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
@@ -127,10 +127,10 @@ namespace Consolonia.Gallery.View
                 ThemesList.TurboVision => new TurboVisionTheme(),
                 _ => throw new InvalidDataException("Unknown theme name")
             };
-            
+
             UpdateThemeMenuItems();
         }
-        
+
         private void OnLoaded(object? sender, RoutedEventArgs routedEventArgs)
         {
             UpdateThemeMenuItems();

--- a/src/Consolonia.Themes/Templates/Controls/Menu.axaml
+++ b/src/Consolonia.Themes/Templates/Controls/Menu.axaml
@@ -81,7 +81,7 @@
     <ControlTheme x:Key="{x:Type Menu}"
                   TargetType="Menu">
         <Setter Property="Background"
-                Value="{DynamicResource ThemeBackgroundBrush}" />
+                Value="{DynamicResource ThemeAlternativeBackgroundBrush}" />
         <Setter Property="ItemContainerTheme"
                 Value="{DynamicResource TopLevelMenuItem}" />
         <Setter Property="Template">


### PR DESCRIPTION
## Summary
- Move theme picker and action buttons into a top menu bar
- Add theme switching via menu items and update checked state accordingly

<img width="1238" height="901" alt="image" src="https://github.com/user-attachments/assets/87ae8148-33f8-452d-99f7-170914791145" />
