### PR TITLE
Add placeholder TurboVision theme variants

### DIFF
--- a/src/Consolonia.Gallery/View/ControlsListView.axaml
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml
@@ -45,6 +45,18 @@
                           Header="TurboVision_Dark"
                           Tag="TurboVisionDark"
                           Click="OnThemeMenuItemClick" />
+                <MenuItem x:Name="ThemeTurboVisionCompatibleMenuItem"
+                          Header="TurboVision_Compatible"
+                          Tag="TurboVisionCompatible"
+                          Click="OnThemeMenuItemClick" />
+                <MenuItem x:Name="ThemeTurboVisionGrayMenuItem"
+                          Header="TurboVision_Gray"
+                          Tag="TurboVisionGray"
+                          Click="OnThemeMenuItemClick" />
+                <MenuItem x:Name="ThemeTurboVisionElegantMenuItem"
+                          Header="TurboVision_Elegant"
+                          Tag="TurboVisionElegant"
+                          Click="OnThemeMenuItemClick" />
             </MenuItem>
             <MenuItem Header="_View"
                       IsTabStop="False">

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml.cs
@@ -17,7 +17,10 @@ namespace Consolonia.Gallery.View
     {
         Modern,
         TurboVision,
-        TurboVisionDark
+        TurboVisionDark,
+        TurboVisionCompatible,
+        TurboVisionGray,
+        TurboVisionElegant
     }
 
     public partial class ControlsListView : Window
@@ -127,6 +130,9 @@ namespace Consolonia.Gallery.View
                 ThemesList.Modern => new ModernTheme(),
                 ThemesList.TurboVision => new TurboVisionTheme(),
                 ThemesList.TurboVisionDark => new TurboVisionDarkTheme(),
+                ThemesList.TurboVisionCompatible => new TurboVisionCompatibleTheme(),
+                ThemesList.TurboVisionGray => new TurboVisionGrayTheme(),
+                ThemesList.TurboVisionElegant => new TurboVisionElegantTheme(),
                 _ => throw new InvalidDataException("Unknown theme name")
             };
 
@@ -145,6 +151,9 @@ namespace Consolonia.Gallery.View
             ThemeModernMenuItem.IsChecked = themeName == nameof(ThemesList.Modern);
             ThemeTurboVisionMenuItem.IsChecked = themeName == nameof(ThemesList.TurboVision);
             ThemeTurboVisionDarkMenuItem.IsChecked = themeName == nameof(ThemesList.TurboVisionDark);
+            ThemeTurboVisionCompatibleMenuItem.IsChecked = themeName == nameof(ThemesList.TurboVisionCompatible);
+            ThemeTurboVisionGrayMenuItem.IsChecked = themeName == nameof(ThemesList.TurboVisionGray);
+            ThemeTurboVisionElegantMenuItem.IsChecked = themeName == nameof(ThemesList.TurboVisionElegant);
         }
     }
 
@@ -159,6 +168,9 @@ namespace Consolonia.Gallery.View
 
         public bool IsTurboVision =>
             SelectedTheme == nameof(ThemesList.TurboVision) ||
-            SelectedTheme == nameof(ThemesList.TurboVisionDark);
+            SelectedTheme == nameof(ThemesList.TurboVisionDark) ||
+            SelectedTheme == nameof(ThemesList.TurboVisionCompatible) ||
+            SelectedTheme == nameof(ThemesList.TurboVisionGray) ||
+            SelectedTheme == nameof(ThemesList.TurboVisionElegant);
     }
 }

--- a/src/Consolonia.Themes/TurboVision/TurboVisionCompatibleColors.axaml
+++ b/src/Consolonia.Themes/TurboVision/TurboVisionCompatibleColors.axaml
@@ -1,0 +1,65 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:consolonia="clr-namespace:Consolonia;assembly=Consolonia.Core">
+    <!-- TurboVision Compatible colors (same as dark for now) -->
+    <system:Double x:Key="FontSizeNormal">1</system:Double>
+
+    <!--Main content foreground. Text on background or alternative background-->
+    <SolidColorBrush x:Key="ThemeForegroundBrush"
+                     Color="{consolonia:EgaColor Gray}" />
+    <!--Main content background.-->
+    <SolidColorBrush x:Key="ThemeBackgroundBrush"
+                     Color="{consolonia:EgaColor Black}" />
+    <!--Alternative to main background. Must fit same foreground.-->
+    <SolidColorBrush x:Key="ThemeAlternativeBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkBlue}" />
+
+    <!--Used to highlight selected but no focused item (selected list item, on switch etc-->
+    <SolidColorBrush x:Key="ThemeChooserBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkYellow}" />
+    <SolidColorBrush x:Key="ThemeChooserForegroundBrush"
+                     Color="{consolonia:EgaColor Black}" />
+
+    <!--Mostly used as focus highlight. But sometimes forced, like turbovision buttons, menu parent item highlight
+                Value must be in some readable contrast with ThemeForegroundBrush-->
+    <SolidColorBrush x:Key="ThemeActionBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkMagenta}" />
+
+    <!--Background of edit items: combobox, textbox-->
+    <SolidColorBrush x:Key="ThemeSelectionBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkCyan}" />
+    <!--Foeground of edit items: combobox, textbox. Must fit background-->
+    <SolidColorBrush x:Key="ThemeSelectionForegroundBrush"
+                     Color="{consolonia:EgaColor White}" />
+
+    <!--Highlights. Access key colors for buttons and menus-->
+    <SolidColorBrush x:Key="ThemeHighlightForegroundBrush"
+                     Color="{consolonia:EgaColor Yellow}" />
+    <SolidColorBrush x:Key="ThemeHighlightForegroundBrush2"
+                     Color="{consolonia:EgaColor Yellow}" />
+
+    <!--Color of borders ( grid borders, panel borders etc)-->
+    <SolidColorBrush x:Key="ThemeBorderBrush"
+                     Color="{consolonia:EgaColor White}" />
+
+    <!--Disabled foreground or background. e.g. disabled menu item foreground, disabled button foreground-->
+    <SolidColorBrush x:Key="ThemeNoDisturbBrush"
+                     Color="{consolonia:EgaColor DarkGray}" />
+
+    <!--Background of the shade pixel. Will be applied to shade background around popups etc, dialogs-->
+    <SolidColorBrush x:Key="ThemeShadeBrush"
+                     Color="{consolonia:EgaColor Mode=Shaded}" />
+    <!--When shade needs to be done using foreground ASCII symbols, not background-->
+    <SolidColorBrush x:Key="ThemePseudoShadeBrush"
+                     Color="{consolonia:EgaColor Black}" />
+
+    <!--Indicating an error, failure etc, foreground only-->
+    <SolidColorBrush x:Key="ThemeErrorBrush"
+                     Color="{consolonia:EgaColor Red}" />
+
+    <!--Just transparent background or foreground-->
+    <SolidColorBrush x:Key="ThemeTransparentBrush"
+                     Color="{consolonia:EgaColor Mode=Transparent}" />
+
+</ResourceDictionary>

--- a/src/Consolonia.Themes/TurboVision/TurboVisionCompatibleTheme.axaml
+++ b/src/Consolonia.Themes/TurboVision/TurboVisionCompatibleTheme.axaml
@@ -1,0 +1,17 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Consolonia.Themes.TurboVisionCompatibleTheme">
+    <Styles.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <MergeResourceInclude Source="/TurboVision/TurboVisionCompatibleColors.axaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <x:String x:Key="ThemeName">TurboVisionCompatible</x:String>
+        </ResourceDictionary>
+    </Styles.Resources>
+
+    <StyleInclude Source="/TurboVision/TurboVisionBase.axaml" />
+    <StyleInclude Source="/TurboVision/Controls/Button.axaml" />
+    <StyleInclude Source="/TurboVision/Controls/ButtonNoShadow.axaml" />
+</Styles>

--- a/src/Consolonia.Themes/TurboVision/TurboVisionElegantColors.axaml
+++ b/src/Consolonia.Themes/TurboVision/TurboVisionElegantColors.axaml
@@ -1,0 +1,65 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:consolonia="clr-namespace:Consolonia;assembly=Consolonia.Core">
+    <!-- TurboVision Elegant colors (same as dark for now) -->
+    <system:Double x:Key="FontSizeNormal">1</system:Double>
+
+    <!--Main content foreground. Text on background or alternative background-->
+    <SolidColorBrush x:Key="ThemeForegroundBrush"
+                     Color="{consolonia:EgaColor Gray}" />
+    <!--Main content background.-->
+    <SolidColorBrush x:Key="ThemeBackgroundBrush"
+                     Color="{consolonia:EgaColor Black}" />
+    <!--Alternative to main background. Must fit same foreground.-->
+    <SolidColorBrush x:Key="ThemeAlternativeBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkBlue}" />
+
+    <!--Used to highlight selected but no focused item (selected list item, on switch etc-->
+    <SolidColorBrush x:Key="ThemeChooserBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkYellow}" />
+    <SolidColorBrush x:Key="ThemeChooserForegroundBrush"
+                     Color="{consolonia:EgaColor Black}" />
+
+    <!--Mostly used as focus highlight. But sometimes forced, like turbovision buttons, menu parent item highlight
+                Value must be in some readable contrast with ThemeForegroundBrush-->
+    <SolidColorBrush x:Key="ThemeActionBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkMagenta}" />
+
+    <!--Background of edit items: combobox, textbox-->
+    <SolidColorBrush x:Key="ThemeSelectionBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkCyan}" />
+    <!--Foeground of edit items: combobox, textbox. Must fit background-->
+    <SolidColorBrush x:Key="ThemeSelectionForegroundBrush"
+                     Color="{consolonia:EgaColor White}" />
+
+    <!--Highlights. Access key colors for buttons and menus-->
+    <SolidColorBrush x:Key="ThemeHighlightForegroundBrush"
+                     Color="{consolonia:EgaColor Yellow}" />
+    <SolidColorBrush x:Key="ThemeHighlightForegroundBrush2"
+                     Color="{consolonia:EgaColor Yellow}" />
+
+    <!--Color of borders ( grid borders, panel borders etc)-->
+    <SolidColorBrush x:Key="ThemeBorderBrush"
+                     Color="{consolonia:EgaColor White}" />
+
+    <!--Disabled foreground or background. e.g. disabled menu item foreground, disabled button foreground-->
+    <SolidColorBrush x:Key="ThemeNoDisturbBrush"
+                     Color="{consolonia:EgaColor DarkGray}" />
+
+    <!--Background of the shade pixel. Will be applied to shade background around popups etc, dialogs-->
+    <SolidColorBrush x:Key="ThemeShadeBrush"
+                     Color="{consolonia:EgaColor Mode=Shaded}" />
+    <!--When shade needs to be done using foreground ASCII symbols, not background-->
+    <SolidColorBrush x:Key="ThemePseudoShadeBrush"
+                     Color="{consolonia:EgaColor Black}" />
+
+    <!--Indicating an error, failure etc, foreground only-->
+    <SolidColorBrush x:Key="ThemeErrorBrush"
+                     Color="{consolonia:EgaColor Red}" />
+
+    <!--Just transparent background or foreground-->
+    <SolidColorBrush x:Key="ThemeTransparentBrush"
+                     Color="{consolonia:EgaColor Mode=Transparent}" />
+
+</ResourceDictionary>

--- a/src/Consolonia.Themes/TurboVision/TurboVisionElegantTheme.axaml
+++ b/src/Consolonia.Themes/TurboVision/TurboVisionElegantTheme.axaml
@@ -1,0 +1,17 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Consolonia.Themes.TurboVisionElegantTheme">
+    <Styles.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <MergeResourceInclude Source="/TurboVision/TurboVisionElegantColors.axaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <x:String x:Key="ThemeName">TurboVisionElegant</x:String>
+        </ResourceDictionary>
+    </Styles.Resources>
+
+    <StyleInclude Source="/TurboVision/TurboVisionBase.axaml" />
+    <StyleInclude Source="/TurboVision/Controls/Button.axaml" />
+    <StyleInclude Source="/TurboVision/Controls/ButtonNoShadow.axaml" />
+</Styles>

--- a/src/Consolonia.Themes/TurboVision/TurboVisionGrayColors.axaml
+++ b/src/Consolonia.Themes/TurboVision/TurboVisionGrayColors.axaml
@@ -1,0 +1,65 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:consolonia="clr-namespace:Consolonia;assembly=Consolonia.Core">
+    <!-- TurboVision Gray colors (same as dark for now) -->
+    <system:Double x:Key="FontSizeNormal">1</system:Double>
+
+    <!--Main content foreground. Text on background or alternative background-->
+    <SolidColorBrush x:Key="ThemeForegroundBrush"
+                     Color="{consolonia:EgaColor Gray}" />
+    <!--Main content background.-->
+    <SolidColorBrush x:Key="ThemeBackgroundBrush"
+                     Color="{consolonia:EgaColor Black}" />
+    <!--Alternative to main background. Must fit same foreground.-->
+    <SolidColorBrush x:Key="ThemeAlternativeBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkBlue}" />
+
+    <!--Used to highlight selected but no focused item (selected list item, on switch etc-->
+    <SolidColorBrush x:Key="ThemeChooserBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkYellow}" />
+    <SolidColorBrush x:Key="ThemeChooserForegroundBrush"
+                     Color="{consolonia:EgaColor Black}" />
+
+    <!--Mostly used as focus highlight. But sometimes forced, like turbovision buttons, menu parent item highlight
+                Value must be in some readable contrast with ThemeForegroundBrush-->
+    <SolidColorBrush x:Key="ThemeActionBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkMagenta}" />
+
+    <!--Background of edit items: combobox, textbox-->
+    <SolidColorBrush x:Key="ThemeSelectionBackgroundBrush"
+                     Color="{consolonia:EgaColor DarkCyan}" />
+    <!--Foeground of edit items: combobox, textbox. Must fit background-->
+    <SolidColorBrush x:Key="ThemeSelectionForegroundBrush"
+                     Color="{consolonia:EgaColor White}" />
+
+    <!--Highlights. Access key colors for buttons and menus-->
+    <SolidColorBrush x:Key="ThemeHighlightForegroundBrush"
+                     Color="{consolonia:EgaColor Yellow}" />
+    <SolidColorBrush x:Key="ThemeHighlightForegroundBrush2"
+                     Color="{consolonia:EgaColor Yellow}" />
+
+    <!--Color of borders ( grid borders, panel borders etc)-->
+    <SolidColorBrush x:Key="ThemeBorderBrush"
+                     Color="{consolonia:EgaColor White}" />
+
+    <!--Disabled foreground or background. e.g. disabled menu item foreground, disabled button foreground-->
+    <SolidColorBrush x:Key="ThemeNoDisturbBrush"
+                     Color="{consolonia:EgaColor DarkGray}" />
+
+    <!--Background of the shade pixel. Will be applied to shade background around popups etc, dialogs-->
+    <SolidColorBrush x:Key="ThemeShadeBrush"
+                     Color="{consolonia:EgaColor Mode=Shaded}" />
+    <!--When shade needs to be done using foreground ASCII symbols, not background-->
+    <SolidColorBrush x:Key="ThemePseudoShadeBrush"
+                     Color="{consolonia:EgaColor Black}" />
+
+    <!--Indicating an error, failure etc, foreground only-->
+    <SolidColorBrush x:Key="ThemeErrorBrush"
+                     Color="{consolonia:EgaColor Red}" />
+
+    <!--Just transparent background or foreground-->
+    <SolidColorBrush x:Key="ThemeTransparentBrush"
+                     Color="{consolonia:EgaColor Mode=Transparent}" />
+
+</ResourceDictionary>

--- a/src/Consolonia.Themes/TurboVision/TurboVisionGrayTheme.axaml
+++ b/src/Consolonia.Themes/TurboVision/TurboVisionGrayTheme.axaml
@@ -1,0 +1,17 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Consolonia.Themes.TurboVisionGrayTheme">
+    <Styles.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <MergeResourceInclude Source="/TurboVision/TurboVisionGrayColors.axaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <x:String x:Key="ThemeName">TurboVisionGray</x:String>
+        </ResourceDictionary>
+    </Styles.Resources>
+
+    <StyleInclude Source="/TurboVision/TurboVisionBase.axaml" />
+    <StyleInclude Source="/TurboVision/Controls/Button.axaml" />
+    <StyleInclude Source="/TurboVision/Controls/ButtonNoShadow.axaml" />
+</Styles>

--- a/src/Consolonia.Themes/TurboVisionCompatibleTheme.cs
+++ b/src/Consolonia.Themes/TurboVisionCompatibleTheme.cs
@@ -1,0 +1,17 @@
+using System;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+
+namespace Consolonia.Themes
+{
+    /// <summary>
+    ///     Turbo Vision theme identical to TurboVisionDark. Placeholder for future customization.
+    /// </summary>
+    public class TurboVisionCompatibleTheme : Styles
+    {
+        public TurboVisionCompatibleTheme(IServiceProvider sp = null)
+        {
+            AvaloniaXamlLoader.Load(sp, this);
+        }
+    }
+}

--- a/src/Consolonia.Themes/TurboVisionElegantTheme.cs
+++ b/src/Consolonia.Themes/TurboVisionElegantTheme.cs
@@ -1,0 +1,17 @@
+using System;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+
+namespace Consolonia.Themes
+{
+    /// <summary>
+    ///     Turbo Vision theme identical to TurboVisionDark. Placeholder for future customization.
+    /// </summary>
+    public class TurboVisionElegantTheme : Styles
+    {
+        public TurboVisionElegantTheme(IServiceProvider sp = null)
+        {
+            AvaloniaXamlLoader.Load(sp, this);
+        }
+    }
+}

--- a/src/Consolonia.Themes/TurboVisionGrayTheme.cs
+++ b/src/Consolonia.Themes/TurboVisionGrayTheme.cs
@@ -1,0 +1,17 @@
+using System;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+
+namespace Consolonia.Themes
+{
+    /// <summary>
+    ///     Turbo Vision theme identical to TurboVisionDark. Placeholder for future customization.
+    /// </summary>
+    public class TurboVisionGrayTheme : Styles
+    {
+        public TurboVisionGrayTheme(IServiceProvider sp = null)
+        {
+            AvaloniaXamlLoader.Load(sp, this);
+        }
+    }
+}

--- a/src/Consolonia.Themes/readme.md
+++ b/src/Consolonia.Themes/readme.md
@@ -10,6 +10,9 @@ This package contains the following Consolonia Themes:
 * **FluentTheme** - Fluent Design theme
 * **TurboVisionTheme** - TurboVision theme
 * **TurboVisionDarkTheme** - TurboVision theme with dark colors
+* **TurboVisionCompatibleTheme** - TurboVision theme identical to TurboVisionDark
+* **TurboVisionGrayTheme** - TurboVision theme identical to TurboVisionDark
+* **TurboVisionElegantTheme** - TurboVision theme identical to TurboVisionDark
 
 # Usage
 Define an application with a theme 


### PR DESCRIPTION
## Summary
- add TurboVisionCompatible, TurboVisionGray and TurboVisionElegant themes mirroring TurboVisionDark
- expose new themes in gallery menu and theme selection logic
- document new TurboVision theme variants

## Testing
- `dotnet test src/Consolonia.sln`

------
https://chatgpt.com/codex/tasks/task_e_68afb12e939c83228c1feec1e6bf8d2c