### PR TITLE
Fix PolyFill starting position

### DIFF
--- a/src/Consolonia.Core/Drawing/StreamGeometryImpl.cs
+++ b/src/Consolonia.Core/Drawing/StreamGeometryImpl.cs
@@ -291,7 +291,7 @@ namespace Consolonia.Core.Drawing
                             double xEnd = intersections[i + 1];
 
                             // Create fill rectangle for this span, excluding the boundary
-                            double fillXStart = xStart + 1;
+                            double fillXStart = xStart;
                             double fillWidth = xEnd - fillXStart;
 
                             if (fillWidth > 0) fillRects.Add(new Rect(fillXStart, y, fillWidth, 1));


### PR DESCRIPTION
Off by one error on complex polyfill starting position.
It looks like this:
<img width="311" height="49" alt="image" src="https://github.com/user-attachments/assets/c48145ba-791d-477c-bd5f-c77cf96bf4e6" />
Should look like this:
<img width="298" height="49" alt="image" src="https://github.com/user-attachments/assets/c57ef591-829f-4461-b9ac-c5a9c57843b6" />
