### PR TITLE
Tabs were messed up

### DIFF
--- a/src/Consolonia.Controls/ControlUtils.cs
+++ b/src/Consolonia.Controls/ControlUtils.cs
@@ -23,6 +23,7 @@ namespace Consolonia.Controls
             return propertyFullName![..^8];
         }
 
+        // ReSharper disable once InconsistentNaming
         private static Lazy<IConsoleCapabilities> _capabilities = new Lazy<IConsoleCapabilities>(() => AvaloniaLocator.Current.GetService<IConsoleCapabilities>());
 
         /// <summary>

--- a/src/Consolonia.Controls/ControlUtils.cs
+++ b/src/Consolonia.Controls/ControlUtils.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Avalonia;
@@ -11,6 +10,10 @@ namespace Consolonia.Controls
 {
     public static class ControlUtils
     {
+        // ReSharper disable once InconsistentNaming
+        private static readonly Lazy<IConsoleCapabilities> _capabilities =
+            new(() => AvaloniaLocator.Current.GetService<IConsoleCapabilities>());
+
         public static IDisposable SubscribeAction<TValue>(
             this IObservable<AvaloniaPropertyChangedEventArgs<TValue>> observable,
             Action<AvaloniaPropertyChangedEventArgs<TValue>> action)
@@ -23,9 +26,6 @@ namespace Consolonia.Controls
             return propertyFullName![..^8];
         }
 
-        // ReSharper disable once InconsistentNaming
-        private static Lazy<IConsoleCapabilities> _capabilities = new Lazy<IConsoleCapabilities>(() => AvaloniaLocator.Current.GetService<IConsoleCapabilities>());
-
         /// <summary>
         ///     Measure text for actual width
         /// </summary>
@@ -35,17 +35,16 @@ namespace Consolonia.Controls
         {
             ArgumentNullException.ThrowIfNull(text);
 
-            var console = _capabilities.Value;
+            IConsoleCapabilities console = _capabilities.Value;
             bool supportsComplexEmoji = console == null || console.SupportsComplexEmoji;
 
             ushort width = 0;
             ushort lastWidth = 0;
             foreach (Rune rune in text.EnumerateRunes())
             {
-                var runeWidth = UnicodeCalculator.GetWidth(rune);
+                int runeWidth = UnicodeCalculator.GetWidth(rune);
                 if (runeWidth >= 0)
                 {
-
                     if (supportsComplexEmoji &&
                         (rune.Value == Emoji.ZeroWidthJoiner || rune.Value == Emoji.ObjectReplacementCharacter))
                         width -= lastWidth;
@@ -66,6 +65,7 @@ namespace Consolonia.Controls
                     }
                 }
             }
+
             return width;
         }
     }

--- a/src/Consolonia.Controls/ControlUtils.cs
+++ b/src/Consolonia.Controls/ControlUtils.cs
@@ -42,7 +42,7 @@ namespace Consolonia.Controls
             foreach (Rune rune in text.EnumerateRunes())
             {
                 var runeWidth = UnicodeCalculator.GetWidth(rune);
-                if (runeWidth > 0)
+                if (runeWidth >= 0)
                 {
 
                     if (supportsComplexEmoji &&
@@ -54,9 +54,9 @@ namespace Consolonia.Controls
                     if (runeWidth > 0)
                         lastWidth = (ushort)runeWidth;
                 }
-                else if (runeWidth < 0)
+                // Control chars return as width < 0
+                else
                 {
-                    // Control chars return as width = -1
                     if (rune.Value == 0x9 /* tab */)
                     {
                         // Avalonia uses hard coded 4 spaces for tabs (NOT column based tabstops), this may change in the future

--- a/src/Consolonia.Controls/ControlUtils.cs
+++ b/src/Consolonia.Controls/ControlUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Avalonia;
@@ -22,6 +23,8 @@ namespace Consolonia.Controls
             return propertyFullName![..^8];
         }
 
+        private static Lazy<IConsoleCapabilities> _capabilities = new Lazy<IConsoleCapabilities>(() => AvaloniaLocator.Current.GetService<IConsoleCapabilities>());
+
         /// <summary>
         ///     Measure text for actual width
         /// </summary>
@@ -29,24 +32,39 @@ namespace Consolonia.Controls
         /// <returns></returns>
         public static ushort MeasureText(this string text)
         {
-            var console = AvaloniaLocator.Current.GetService<IConsoleCapabilities>();
+            ArgumentNullException.ThrowIfNull(text);
+
+            var console = _capabilities.Value;
             bool supportsComplexEmoji = console == null || console.SupportsComplexEmoji;
 
             ushort width = 0;
             ushort lastWidth = 0;
             foreach (Rune rune in text.EnumerateRunes())
             {
-                ushort runeWidth = (ushort)UnicodeCalculator.GetWidth(rune);
-                if (supportsComplexEmoji &&
-                    (rune.Value == Emoji.ZeroWidthJoiner || rune.Value == Emoji.ObjectReplacementCharacter))
-                    width -= lastWidth;
-                else
-                    width += runeWidth;
-
+                var runeWidth = UnicodeCalculator.GetWidth(rune);
                 if (runeWidth > 0)
-                    lastWidth = runeWidth;
-            }
+                {
 
+                    if (supportsComplexEmoji &&
+                        (rune.Value == Emoji.ZeroWidthJoiner || rune.Value == Emoji.ObjectReplacementCharacter))
+                        width -= lastWidth;
+                    else
+                        width += (ushort)runeWidth;
+
+                    if (runeWidth > 0)
+                        lastWidth = (ushort)runeWidth;
+                }
+                else if (runeWidth < 0)
+                {
+                    // Control chars return as width = -1
+                    if (rune.Value == 0x9 /* tab */)
+                    {
+                        // Avalonia uses hard coded 4 spaces for tabs (NOT column based tabstops), this may change in the future
+                        width += 4;
+                        lastWidth = 4;
+                    }
+                }
+            }
             return width;
         }
     }

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -6,6 +6,7 @@ using Avalonia;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
 using Avalonia.Platform;
+using Consolonia.Controls;
 using Consolonia.Controls.Brushes;
 using Consolonia.Core.Drawing.PixelBufferImplementation;
 using Consolonia.Core.Helpers;
@@ -101,37 +102,37 @@ namespace Consolonia.Core.Drawing
                 new SKPaint { FilterQuality = SKFilterQuality.Medium });
 
             for (int y = 0; y < bitmap.Info.Height; y += 2)
-            for (int x = 0; x < bitmap.Info.Width; x += 2)
-            {
-                // NOTE: we divide by 2 because we are working with quad pixels,
-                // // the bitmap has twice the horizontal and twice the vertical of the target rect.
-                int px = (int)targetRect.TopLeft.X + x / 2;
-                int py = (int)targetRect.TopLeft.Y + y / 2;
+                for (int x = 0; x < bitmap.Info.Width; x += 2)
+                {
+                    // NOTE: we divide by 2 because we are working with quad pixels,
+                    // // the bitmap has twice the horizontal and twice the vertical of the target rect.
+                    int px = (int)targetRect.TopLeft.X + x / 2;
+                    int py = (int)targetRect.TopLeft.Y + y / 2;
 
-                // get the quad pixel the bitmap
-                SKColor[] quadColors =
-                [
-                    bitmap.GetPixel(x, y), bitmap.GetPixel(x + 1, y),
+                    // get the quad pixel the bitmap
+                    SKColor[] quadColors =
+                    [
+                        bitmap.GetPixel(x, y), bitmap.GetPixel(x + 1, y),
                     bitmap.GetPixel(x, y + 1), bitmap.GetPixel(x + 1, y + 1)
-                ];
+                    ];
 
-                // map it to a single char to represent the 4 pixels
-                char quadPixel = GetQuadPixelCharacter(quadColors);
+                    // map it to a single char to represent the 4 pixels
+                    char quadPixel = GetQuadPixelCharacter(quadColors);
 
-                // get the combined colors for the quad pixel
-                Color foreground = GetForegroundColorForQuadPixel(quadColors, quadPixel);
-                Color background = GetBackgroundColorForQuadPixel(quadColors, quadPixel);
+                    // get the combined colors for the quad pixel
+                    Color foreground = GetForegroundColorForQuadPixel(quadColors, quadPixel);
+                    Color background = GetBackgroundColorForQuadPixel(quadColors, quadPixel);
 
-                var imagePixel = new Pixel(
-                    new PixelForeground(new SimpleSymbol(quadPixel), foreground),
-                    new PixelBackground(background));
-                CurrentClip.ExecuteWithClipping(new Point(px, py),
+                    var imagePixel = new Pixel(
+                        new PixelForeground(new SimpleSymbol(quadPixel), foreground),
+                        new PixelBackground(background));
+                    CurrentClip.ExecuteWithClipping(new Point(px, py),
                     () =>
                     {
                         _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
-                            existingPixel => existingPixel.Blend(imagePixel));
+                        existingPixel => existingPixel.Blend(imagePixel));
                     });
-            }
+                }
 
             var rectToRefresh = new Rect((int)targetRect.TopLeft.X, (int)targetRect.TopLeft.Y, (int)targetRect.Width,
                 (int)targetRect.Height);
@@ -160,33 +161,33 @@ namespace Consolonia.Core.Drawing
                     DrawLineInternal(pen, myLine);
                     break;
                 case StreamGeometryImpl streamGeometry:
-                {
-                    // if we have fills to do.
-                    if (streamGeometry.Fills.Count > 0)
-                        foreach (Rectangle fill in streamGeometry.Fills)
-                            DrawRectangle(brush, pen, new RoundedRect(fill.Rect));
-
-                    // if we have strokes to draw
-                    if (streamGeometry.Strokes.Count > 0)
                     {
-                        pen ??= new Pen(brush);
+                        // if we have fills to do.
+                        if (streamGeometry.Fills.Count > 0)
+                            foreach (Rectangle fill in streamGeometry.Fills)
+                                DrawRectangle(brush, pen, new RoundedRect(fill.Rect));
 
-                        RectangleLinePosition[] strokePositions = InferStrokePositions(streamGeometry);
-                        for (int iStroke = 0; iStroke < streamGeometry.Strokes.Count; iStroke++)
+                        // if we have strokes to draw
+                        if (streamGeometry.Strokes.Count > 0)
                         {
-                            Line stroke = streamGeometry.Strokes[iStroke];
-                            RectangleLinePosition strokePosition = strokePositions[iStroke];
-                            if (strokePosition == RectangleLinePosition.Left)
-                                DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Left);
-                            else if (strokePosition == RectangleLinePosition.Right)
-                                DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Right);
-                            else if (strokePosition == RectangleLinePosition.Top)
-                                DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Top);
-                            else if (strokePosition == RectangleLinePosition.Bottom)
-                                DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Bottom);
+                            pen ??= new Pen(brush);
+
+                            RectangleLinePosition[] strokePositions = InferStrokePositions(streamGeometry);
+                            for (int iStroke = 0; iStroke < streamGeometry.Strokes.Count; iStroke++)
+                            {
+                                Line stroke = streamGeometry.Strokes[iStroke];
+                                RectangleLinePosition strokePosition = strokePositions[iStroke];
+                                if (strokePosition == RectangleLinePosition.Left)
+                                    DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Left);
+                                else if (strokePosition == RectangleLinePosition.Right)
+                                    DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Right);
+                                else if (strokePosition == RectangleLinePosition.Top)
+                                    DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Top);
+                                else if (strokePosition == RectangleLinePosition.Bottom)
+                                    DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Bottom);
+                            }
                         }
                     }
-                }
                     break;
                 default:
                     ConsoloniaPlatform.RaiseNotSupported(NotSupportedRequestCode.DrawGeometryNotSupported, this, brush,
@@ -227,23 +228,23 @@ namespace Consolonia.Core.Drawing
                     case VisualBrush:
                         throw new NotImplementedException();
                     case ISceneBrush sceneBrush:
-                    {
-                        ISceneBrushContent sceneBrushContent = sceneBrush.CreateContent();
-                        sceneBrushContent?.Render(this, Matrix.Identity);
-                        return;
-                    }
+                        {
+                            ISceneBrushContent sceneBrushContent = sceneBrush.CreateContent();
+                            sceneBrushContent?.Render(this, Matrix.Identity);
+                            return;
+                        }
                     case MoveConsoleCaretToPositionBrush moveBrush:
-                    {
-                        Point head = r.TopLeft.Transform(Transform);
-                        CurrentClip.ExecuteWithClipping(head,
-                            () =>
-                            {
-                                _pixelBuffer.Set((PixelBufferCoordinate)head,
-                                    pixel => pixel.Blend(new Pixel(moveBrush.CaretStyle)));
-                            });
-                        _consoleWindowImpl.DirtyRegions.AddRect(CurrentClip.Intersect(new Rect(head, new Size(1, 1))));
-                        return;
-                    }
+                        {
+                            Point head = r.TopLeft.Transform(Transform);
+                            CurrentClip.ExecuteWithClipping(head,
+                                () =>
+                                {
+                                    _pixelBuffer.Set((PixelBufferCoordinate)head,
+                                        pixel => pixel.Blend(new Pixel(moveBrush.CaretStyle)));
+                                });
+                            _consoleWindowImpl.DirtyRegions.AddRect(CurrentClip.Intersect(new Rect(head, new Size(1, 1))));
+                            return;
+                        }
                 }
 
                 FillRectangleWithBrush(brush, pen, r);
@@ -509,31 +510,31 @@ namespace Consolonia.Core.Drawing
             double width = r2.Width + (pen?.Thickness ?? 0);
             double height = r2.Height + (pen?.Thickness ?? 0);
             for (int x = 0; x < width; x++)
-            for (int y = 0; y < height; y++)
-            {
-                int px = (int)(r2.TopLeft.X + x);
-                int py = (int)(r2.TopLeft.Y + y);
-                Color backgroundColor = brush.FromPosition(x, y, (int)width, (int)height);
-
-                CurrentClip.ExecuteWithClipping(new Point(px, py), () =>
+                for (int y = 0; y < height; y++)
                 {
-                    _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
-                        pixel =>
-                        {
-                            switch (brush)
+                    int px = (int)(r2.TopLeft.X + x);
+                    int py = (int)(r2.TopLeft.Y + y);
+                    Color backgroundColor = brush.FromPosition(x, y, (int)width, (int)height);
+
+                    CurrentClip.ExecuteWithClipping(new Point(px, py), () =>
+                    {
+                        _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
+                            pixel =>
                             {
-                                case ShadeBrush:
-                                    return pixel.Shade();
-                                case BrightenBrush:
-                                    return pixel.Brighten();
-                                case InvertBrush:
-                                    return pixel.Invert();
-                                default:
-                                    return pixel.Blend(new Pixel(new PixelBackground(backgroundColor)));
-                            }
-                        });
-                });
-            }
+                                switch (brush)
+                                {
+                                    case ShadeBrush:
+                                        return pixel.Shade();
+                                    case BrightenBrush:
+                                        return pixel.Brighten();
+                                    case InvertBrush:
+                                        return pixel.Invert();
+                                    default:
+                                        return pixel.Blend(new Pixel(new PixelBackground(backgroundColor)));
+                                }
+                            });
+                    });
+                }
 
             _consoleWindowImpl.DirtyRegions.AddRect(CurrentClip.Intersect(new Rect(r2.TopLeft, r2.Size)));
         }
@@ -773,21 +774,7 @@ namespace Consolonia.Core.Drawing
                 switch (glyph)
                 {
                     case "\t":
-                    {
-                        const int tabSize = 8;
-                        var consolePixel = new Pixel(new SimpleSymbol(' '), foregroundColor);
-                        for (int j = 0; j < tabSize; j++)
-                        {
-                            Point newCharacterPoint = characterPoint.WithX(characterPoint.X + j);
-                            CurrentClip.ExecuteWithClipping(newCharacterPoint, () =>
-                            {
-                                _pixelBuffer.Set((PixelBufferCoordinate)newCharacterPoint,
-                                    oldPixel => oldPixel.Blend(consolePixel));
-                            });
-                        }
-
-                        currentXPosition += tabSize - 1;
-                    }
+                        currentXPosition += glyph.MeasureText();
                         break;
                     case "\r":
                     case "\f":
@@ -796,66 +783,66 @@ namespace Consolonia.Core.Drawing
                         currentYPosition++;
                         break;
                     default:
-                    {
-                        var symbol = new SimpleSymbol(glyph);
-                        // if we are attempting to draw a wide glyph we need to make sure that the clipping point
-                        // is for the last physical char. Aka a double char should be clipped if it's second rendered 
-                        // char would break the boundary of the clip.
-                        // var clippingPoint = new Point(characterPoint.X + symbol.Width - 1, characterPoint.Y);
-                        var newPixel = new Pixel(symbol, foregroundColor, typeface.Style, typeface.Weight);
-                        CurrentClip.ExecuteWithClipping(characterPoint, () =>
                         {
-                            _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
-                                oldPixel =>
-                                {
-                                    if (oldPixel.Width == 0)
+                            var symbol = new SimpleSymbol(glyph);
+                            // if we are attempting to draw a wide glyph we need to make sure that the clipping point
+                            // is for the last physical char. Aka a double char should be clipped if it's second rendered 
+                            // char would break the boundary of the clip.
+                            // var clippingPoint = new Point(characterPoint.X + symbol.Width - 1, characterPoint.Y);
+                            var newPixel = new Pixel(symbol, foregroundColor, typeface.Style, typeface.Weight);
+                            CurrentClip.ExecuteWithClipping(characterPoint, () =>
+                            {
+                                _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
+                                    oldPixel =>
                                     {
-                                        // if the oldPixel was empty, we need to set the previous pixel to space
-                                        double targetX = characterPoint.X - 1;
-                                        if (targetX >= 0)
-                                            _pixelBuffer.Set(
-                                                (PixelBufferCoordinate)new Point(targetX, characterPoint.Y),
-                                                oldPixel2 =>
-                                                    new Pixel(
-                                                        new PixelForeground(new SimpleSymbol(' '), Colors.Transparent),
-                                                        oldPixel2.Background));
-                                    }
-                                    else if (oldPixel.Width > 1)
-                                    {
-                                        // if oldPixel was wide we need to reset overlapped symbols from empty to space
-                                        for (ushort i = 1; i < oldPixel.Width; i++)
+                                        if (oldPixel.Width == 0)
                                         {
-                                            double targetX = characterPoint.X + i;
-                                            if (targetX < _pixelBuffer.Size.Width)
+                                            // if the oldPixel was empty, we need to set the previous pixel to space
+                                            double targetX = characterPoint.X - 1;
+                                            if (targetX >= 0)
                                                 _pixelBuffer.Set(
                                                     (PixelBufferCoordinate)new Point(targetX, characterPoint.Y),
                                                     oldPixel2 =>
                                                         new Pixel(
-                                                            new PixelForeground(new SimpleSymbol(' '),
-                                                                Colors.Transparent), oldPixel2.Background));
-                                        }
-                                    }
-
-                                    // if the pixel was a wide character, we need to set the overlapped pixels to empty pixels.
-                                    if (newPixel.Width > 1)
-                                        for (int i = 1; i < symbol.Width; i++)
-                                        {
-                                            double targetX = characterPoint.X + i;
-                                            if (targetX < _pixelBuffer.Size.Width)
-                                                _pixelBuffer.Set(
-                                                    (PixelBufferCoordinate)new Point(targetX, characterPoint.Y),
-                                                    oldPixel2 =>
-                                                        new Pixel(
-                                                            new PixelForeground(new SimpleSymbol(), Colors.Transparent),
+                                                            new PixelForeground(new SimpleSymbol(' '), Colors.Transparent),
                                                             oldPixel2.Background));
                                         }
+                                        else if (oldPixel.Width > 1)
+                                        {
+                                            // if oldPixel was wide we need to reset overlapped symbols from empty to space
+                                            for (ushort i = 1; i < oldPixel.Width; i++)
+                                            {
+                                                double targetX = characterPoint.X + i;
+                                                if (targetX < _pixelBuffer.Size.Width)
+                                                    _pixelBuffer.Set(
+                                                        (PixelBufferCoordinate)new Point(targetX, characterPoint.Y),
+                                                        oldPixel2 =>
+                                                            new Pixel(
+                                                                new PixelForeground(new SimpleSymbol(' '),
+                                                                    Colors.Transparent), oldPixel2.Background));
+                                            }
+                                        }
 
-                                    return oldPixel.Blend(newPixel);
-                                });
-                        });
+                                        // if the pixel was a wide character, we need to set the overlapped pixels to empty pixels.
+                                        if (newPixel.Width > 1)
+                                            for (int i = 1; i < symbol.Width; i++)
+                                            {
+                                                double targetX = characterPoint.X + i;
+                                                if (targetX < _pixelBuffer.Size.Width)
+                                                    _pixelBuffer.Set(
+                                                        (PixelBufferCoordinate)new Point(targetX, characterPoint.Y),
+                                                        oldPixel2 =>
+                                                            new Pixel(
+                                                                new PixelForeground(new SimpleSymbol(), Colors.Transparent),
+                                                                oldPixel2.Background));
+                                            }
 
-                        currentXPosition += symbol.Width;
-                    }
+                                        return oldPixel.Blend(newPixel);
+                                    });
+                            });
+
+                            currentXPosition += symbol.Width;
+                        }
                         break;
                 }
             }
@@ -969,13 +956,6 @@ namespace Consolonia.Core.Drawing
             return Color.FromArgb(skColor.Alpha, skColor.Red, skColor.Green, skColor.Blue);
         }
 
-        //private static SKColor CombineColors(params SKColor[] colors)
-        //{
-        //    return new SKColor((byte)colors.Average(c => c.Red),
-        //                       (byte)colors.Average(c => c.Green),
-        //                       (byte)colors.Average(c => c.Blue),
-        //                       (byte)colors.Average(c => c.Alpha));
-        //}
 
         private static SKColor CombineColors(params SKColor[] colors)
         {

--- a/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
+++ b/src/Consolonia.Core/Drawing/DrawingContextImpl.cs
@@ -102,37 +102,37 @@ namespace Consolonia.Core.Drawing
                 new SKPaint { FilterQuality = SKFilterQuality.Medium });
 
             for (int y = 0; y < bitmap.Info.Height; y += 2)
-                for (int x = 0; x < bitmap.Info.Width; x += 2)
-                {
-                    // NOTE: we divide by 2 because we are working with quad pixels,
-                    // // the bitmap has twice the horizontal and twice the vertical of the target rect.
-                    int px = (int)targetRect.TopLeft.X + x / 2;
-                    int py = (int)targetRect.TopLeft.Y + y / 2;
+            for (int x = 0; x < bitmap.Info.Width; x += 2)
+            {
+                // NOTE: we divide by 2 because we are working with quad pixels,
+                // // the bitmap has twice the horizontal and twice the vertical of the target rect.
+                int px = (int)targetRect.TopLeft.X + x / 2;
+                int py = (int)targetRect.TopLeft.Y + y / 2;
 
-                    // get the quad pixel the bitmap
-                    SKColor[] quadColors =
-                    [
-                        bitmap.GetPixel(x, y), bitmap.GetPixel(x + 1, y),
+                // get the quad pixel the bitmap
+                SKColor[] quadColors =
+                [
+                    bitmap.GetPixel(x, y), bitmap.GetPixel(x + 1, y),
                     bitmap.GetPixel(x, y + 1), bitmap.GetPixel(x + 1, y + 1)
-                    ];
+                ];
 
-                    // map it to a single char to represent the 4 pixels
-                    char quadPixel = GetQuadPixelCharacter(quadColors);
+                // map it to a single char to represent the 4 pixels
+                char quadPixel = GetQuadPixelCharacter(quadColors);
 
-                    // get the combined colors for the quad pixel
-                    Color foreground = GetForegroundColorForQuadPixel(quadColors, quadPixel);
-                    Color background = GetBackgroundColorForQuadPixel(quadColors, quadPixel);
+                // get the combined colors for the quad pixel
+                Color foreground = GetForegroundColorForQuadPixel(quadColors, quadPixel);
+                Color background = GetBackgroundColorForQuadPixel(quadColors, quadPixel);
 
-                    var imagePixel = new Pixel(
-                        new PixelForeground(new SimpleSymbol(quadPixel), foreground),
-                        new PixelBackground(background));
-                    CurrentClip.ExecuteWithClipping(new Point(px, py),
+                var imagePixel = new Pixel(
+                    new PixelForeground(new SimpleSymbol(quadPixel), foreground),
+                    new PixelBackground(background));
+                CurrentClip.ExecuteWithClipping(new Point(px, py),
                     () =>
                     {
                         _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
-                        existingPixel => existingPixel.Blend(imagePixel));
+                            existingPixel => existingPixel.Blend(imagePixel));
                     });
-                }
+            }
 
             var rectToRefresh = new Rect((int)targetRect.TopLeft.X, (int)targetRect.TopLeft.Y, (int)targetRect.Width,
                 (int)targetRect.Height);
@@ -161,33 +161,33 @@ namespace Consolonia.Core.Drawing
                     DrawLineInternal(pen, myLine);
                     break;
                 case StreamGeometryImpl streamGeometry:
+                {
+                    // if we have fills to do.
+                    if (streamGeometry.Fills.Count > 0)
+                        foreach (Rectangle fill in streamGeometry.Fills)
+                            DrawRectangle(brush, pen, new RoundedRect(fill.Rect));
+
+                    // if we have strokes to draw
+                    if (streamGeometry.Strokes.Count > 0)
                     {
-                        // if we have fills to do.
-                        if (streamGeometry.Fills.Count > 0)
-                            foreach (Rectangle fill in streamGeometry.Fills)
-                                DrawRectangle(brush, pen, new RoundedRect(fill.Rect));
+                        pen ??= new Pen(brush);
 
-                        // if we have strokes to draw
-                        if (streamGeometry.Strokes.Count > 0)
+                        RectangleLinePosition[] strokePositions = InferStrokePositions(streamGeometry);
+                        for (int iStroke = 0; iStroke < streamGeometry.Strokes.Count; iStroke++)
                         {
-                            pen ??= new Pen(brush);
-
-                            RectangleLinePosition[] strokePositions = InferStrokePositions(streamGeometry);
-                            for (int iStroke = 0; iStroke < streamGeometry.Strokes.Count; iStroke++)
-                            {
-                                Line stroke = streamGeometry.Strokes[iStroke];
-                                RectangleLinePosition strokePosition = strokePositions[iStroke];
-                                if (strokePosition == RectangleLinePosition.Left)
-                                    DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Left);
-                                else if (strokePosition == RectangleLinePosition.Right)
-                                    DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Right);
-                                else if (strokePosition == RectangleLinePosition.Top)
-                                    DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Top);
-                                else if (strokePosition == RectangleLinePosition.Bottom)
-                                    DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Bottom);
-                            }
+                            Line stroke = streamGeometry.Strokes[iStroke];
+                            RectangleLinePosition strokePosition = strokePositions[iStroke];
+                            if (strokePosition == RectangleLinePosition.Left)
+                                DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Left);
+                            else if (strokePosition == RectangleLinePosition.Right)
+                                DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Right);
+                            else if (strokePosition == RectangleLinePosition.Top)
+                                DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Top);
+                            else if (strokePosition == RectangleLinePosition.Bottom)
+                                DrawBoxLineInternal(pen, stroke, RectangleLinePosition.Bottom);
                         }
                     }
+                }
                     break;
                 default:
                     ConsoloniaPlatform.RaiseNotSupported(NotSupportedRequestCode.DrawGeometryNotSupported, this, brush,
@@ -228,23 +228,23 @@ namespace Consolonia.Core.Drawing
                     case VisualBrush:
                         throw new NotImplementedException();
                     case ISceneBrush sceneBrush:
-                        {
-                            ISceneBrushContent sceneBrushContent = sceneBrush.CreateContent();
-                            sceneBrushContent?.Render(this, Matrix.Identity);
-                            return;
-                        }
+                    {
+                        ISceneBrushContent sceneBrushContent = sceneBrush.CreateContent();
+                        sceneBrushContent?.Render(this, Matrix.Identity);
+                        return;
+                    }
                     case MoveConsoleCaretToPositionBrush moveBrush:
-                        {
-                            Point head = r.TopLeft.Transform(Transform);
-                            CurrentClip.ExecuteWithClipping(head,
-                                () =>
-                                {
-                                    _pixelBuffer.Set((PixelBufferCoordinate)head,
-                                        pixel => pixel.Blend(new Pixel(moveBrush.CaretStyle)));
-                                });
-                            _consoleWindowImpl.DirtyRegions.AddRect(CurrentClip.Intersect(new Rect(head, new Size(1, 1))));
-                            return;
-                        }
+                    {
+                        Point head = r.TopLeft.Transform(Transform);
+                        CurrentClip.ExecuteWithClipping(head,
+                            () =>
+                            {
+                                _pixelBuffer.Set((PixelBufferCoordinate)head,
+                                    pixel => pixel.Blend(new Pixel(moveBrush.CaretStyle)));
+                            });
+                        _consoleWindowImpl.DirtyRegions.AddRect(CurrentClip.Intersect(new Rect(head, new Size(1, 1))));
+                        return;
+                    }
                 }
 
                 FillRectangleWithBrush(brush, pen, r);
@@ -510,31 +510,31 @@ namespace Consolonia.Core.Drawing
             double width = r2.Width + (pen?.Thickness ?? 0);
             double height = r2.Height + (pen?.Thickness ?? 0);
             for (int x = 0; x < width; x++)
-                for (int y = 0; y < height; y++)
-                {
-                    int px = (int)(r2.TopLeft.X + x);
-                    int py = (int)(r2.TopLeft.Y + y);
-                    Color backgroundColor = brush.FromPosition(x, y, (int)width, (int)height);
+            for (int y = 0; y < height; y++)
+            {
+                int px = (int)(r2.TopLeft.X + x);
+                int py = (int)(r2.TopLeft.Y + y);
+                Color backgroundColor = brush.FromPosition(x, y, (int)width, (int)height);
 
-                    CurrentClip.ExecuteWithClipping(new Point(px, py), () =>
-                    {
-                        _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
-                            pixel =>
+                CurrentClip.ExecuteWithClipping(new Point(px, py), () =>
+                {
+                    _pixelBuffer.Set(new PixelBufferCoordinate((ushort)px, (ushort)py),
+                        pixel =>
+                        {
+                            switch (brush)
                             {
-                                switch (brush)
-                                {
-                                    case ShadeBrush:
-                                        return pixel.Shade();
-                                    case BrightenBrush:
-                                        return pixel.Brighten();
-                                    case InvertBrush:
-                                        return pixel.Invert();
-                                    default:
-                                        return pixel.Blend(new Pixel(new PixelBackground(backgroundColor)));
-                                }
-                            });
-                    });
-                }
+                                case ShadeBrush:
+                                    return pixel.Shade();
+                                case BrightenBrush:
+                                    return pixel.Brighten();
+                                case InvertBrush:
+                                    return pixel.Invert();
+                                default:
+                                    return pixel.Blend(new Pixel(new PixelBackground(backgroundColor)));
+                            }
+                        });
+                });
+            }
 
             _consoleWindowImpl.DirtyRegions.AddRect(CurrentClip.Intersect(new Rect(r2.TopLeft, r2.Size)));
         }
@@ -783,66 +783,66 @@ namespace Consolonia.Core.Drawing
                         currentYPosition++;
                         break;
                     default:
+                    {
+                        var symbol = new SimpleSymbol(glyph);
+                        // if we are attempting to draw a wide glyph we need to make sure that the clipping point
+                        // is for the last physical char. Aka a double char should be clipped if it's second rendered 
+                        // char would break the boundary of the clip.
+                        // var clippingPoint = new Point(characterPoint.X + symbol.Width - 1, characterPoint.Y);
+                        var newPixel = new Pixel(symbol, foregroundColor, typeface.Style, typeface.Weight);
+                        CurrentClip.ExecuteWithClipping(characterPoint, () =>
                         {
-                            var symbol = new SimpleSymbol(glyph);
-                            // if we are attempting to draw a wide glyph we need to make sure that the clipping point
-                            // is for the last physical char. Aka a double char should be clipped if it's second rendered 
-                            // char would break the boundary of the clip.
-                            // var clippingPoint = new Point(characterPoint.X + symbol.Width - 1, characterPoint.Y);
-                            var newPixel = new Pixel(symbol, foregroundColor, typeface.Style, typeface.Weight);
-                            CurrentClip.ExecuteWithClipping(characterPoint, () =>
-                            {
-                                _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
-                                    oldPixel =>
+                            _pixelBuffer.Set((PixelBufferCoordinate)characterPoint,
+                                oldPixel =>
+                                {
+                                    if (oldPixel.Width == 0)
                                     {
-                                        if (oldPixel.Width == 0)
+                                        // if the oldPixel was empty, we need to set the previous pixel to space
+                                        double targetX = characterPoint.X - 1;
+                                        if (targetX >= 0)
+                                            _pixelBuffer.Set(
+                                                (PixelBufferCoordinate)new Point(targetX, characterPoint.Y),
+                                                oldPixel2 =>
+                                                    new Pixel(
+                                                        new PixelForeground(new SimpleSymbol(' '), Colors.Transparent),
+                                                        oldPixel2.Background));
+                                    }
+                                    else if (oldPixel.Width > 1)
+                                    {
+                                        // if oldPixel was wide we need to reset overlapped symbols from empty to space
+                                        for (ushort i = 1; i < oldPixel.Width; i++)
                                         {
-                                            // if the oldPixel was empty, we need to set the previous pixel to space
-                                            double targetX = characterPoint.X - 1;
-                                            if (targetX >= 0)
+                                            double targetX = characterPoint.X + i;
+                                            if (targetX < _pixelBuffer.Size.Width)
                                                 _pixelBuffer.Set(
                                                     (PixelBufferCoordinate)new Point(targetX, characterPoint.Y),
                                                     oldPixel2 =>
                                                         new Pixel(
-                                                            new PixelForeground(new SimpleSymbol(' '), Colors.Transparent),
+                                                            new PixelForeground(new SimpleSymbol(' '),
+                                                                Colors.Transparent), oldPixel2.Background));
+                                        }
+                                    }
+
+                                    // if the pixel was a wide character, we need to set the overlapped pixels to empty pixels.
+                                    if (newPixel.Width > 1)
+                                        for (int i = 1; i < symbol.Width; i++)
+                                        {
+                                            double targetX = characterPoint.X + i;
+                                            if (targetX < _pixelBuffer.Size.Width)
+                                                _pixelBuffer.Set(
+                                                    (PixelBufferCoordinate)new Point(targetX, characterPoint.Y),
+                                                    oldPixel2 =>
+                                                        new Pixel(
+                                                            new PixelForeground(new SimpleSymbol(), Colors.Transparent),
                                                             oldPixel2.Background));
                                         }
-                                        else if (oldPixel.Width > 1)
-                                        {
-                                            // if oldPixel was wide we need to reset overlapped symbols from empty to space
-                                            for (ushort i = 1; i < oldPixel.Width; i++)
-                                            {
-                                                double targetX = characterPoint.X + i;
-                                                if (targetX < _pixelBuffer.Size.Width)
-                                                    _pixelBuffer.Set(
-                                                        (PixelBufferCoordinate)new Point(targetX, characterPoint.Y),
-                                                        oldPixel2 =>
-                                                            new Pixel(
-                                                                new PixelForeground(new SimpleSymbol(' '),
-                                                                    Colors.Transparent), oldPixel2.Background));
-                                            }
-                                        }
 
-                                        // if the pixel was a wide character, we need to set the overlapped pixels to empty pixels.
-                                        if (newPixel.Width > 1)
-                                            for (int i = 1; i < symbol.Width; i++)
-                                            {
-                                                double targetX = characterPoint.X + i;
-                                                if (targetX < _pixelBuffer.Size.Width)
-                                                    _pixelBuffer.Set(
-                                                        (PixelBufferCoordinate)new Point(targetX, characterPoint.Y),
-                                                        oldPixel2 =>
-                                                            new Pixel(
-                                                                new PixelForeground(new SimpleSymbol(), Colors.Transparent),
-                                                                oldPixel2.Background));
-                                            }
+                                    return oldPixel.Blend(newPixel);
+                                });
+                        });
 
-                                        return oldPixel.Blend(newPixel);
-                                    });
-                            });
-
-                            currentXPosition += symbol.Width;
-                        }
+                        currentXPosition += symbol.Width;
+                    }
                         break;
                 }
             }

--- a/src/Consolonia.Core/Drawing/PixelBufferImplementation/Pixel.cs
+++ b/src/Consolonia.Core/Drawing/PixelBufferImplementation/Pixel.cs
@@ -166,6 +166,7 @@ namespace Consolonia.Core.Drawing.PixelBufferImplementation
             return new Pixel(newForeground, newBackground, newCaretStyle);
         }
 
+        // ReSharper disable once InconsistentNaming
         private static Lazy<IConsoleColorMode> _consoleColorMode = new Lazy<IConsoleColorMode>(() => AvaloniaLocator.Current.GetRequiredService<IConsoleColorMode>());
 
         /// <summary>

--- a/src/Consolonia.Core/Drawing/PixelBufferImplementation/Pixel.cs
+++ b/src/Consolonia.Core/Drawing/PixelBufferImplementation/Pixel.cs
@@ -166,6 +166,8 @@ namespace Consolonia.Core.Drawing.PixelBufferImplementation
             return new Pixel(newForeground, newBackground, newCaretStyle);
         }
 
+        private static Lazy<IConsoleColorMode> _consoleColorMode = new Lazy<IConsoleColorMode>(() => AvaloniaLocator.Current.GetRequiredService<IConsoleColorMode>());
+
         /// <summary>
         ///     merge colors with alpha blending
         /// </summary>
@@ -174,8 +176,7 @@ namespace Consolonia.Core.Drawing.PixelBufferImplementation
         /// <returns>source blended into target</returns>
         private static Color MergeColors(Color target, Color source)
         {
-            var consoleColorMode = AvaloniaLocator.Current.GetRequiredService<IConsoleColorMode>();
-            return consoleColorMode.Blend(target, source);
+            return _consoleColorMode.Value.Blend(target, source);
         }
 
         public override bool Equals([NotNullWhen(true)] object obj)

--- a/src/Consolonia.Core/Drawing/PixelBufferImplementation/Pixel.cs
+++ b/src/Consolonia.Core/Drawing/PixelBufferImplementation/Pixel.cs
@@ -167,7 +167,8 @@ namespace Consolonia.Core.Drawing.PixelBufferImplementation
         }
 
         // ReSharper disable once InconsistentNaming
-        private static Lazy<IConsoleColorMode> _consoleColorMode = new Lazy<IConsoleColorMode>(() => AvaloniaLocator.Current.GetRequiredService<IConsoleColorMode>());
+        private static readonly Lazy<IConsoleColorMode> _consoleColorMode =
+            new(() => AvaloniaLocator.Current.GetRequiredService<IConsoleColorMode>());
 
         /// <summary>
         ///     merge colors with alpha blending

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryTextBox.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryTextBox.axaml
@@ -13,13 +13,13 @@
                     Margin="1,0">
             <!--<StackPanel.Styles>
             <Style Selector="TextBox">
-                <Setter Property="HorizontalAlignment"
-                        Value="Left" />
-                <Setter Property="Width"
-                        Value="35" />
+            <Setter Property="HorizontalAlignment"
+            Value="Left" />
+            <Setter Property="Width"
+            Value="35" />
             </Style>
-        </StackPanel.Styles>-->
-            <TextBox Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit.">
+            </StackPanel.Styles>-->
+            <TextBox Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." AcceptsTab="True">
                 <TextBox.ContextFlyout>
                     <Flyout>
                         <TextBlock>Custom context flyout</TextBlock>

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryTextBox.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryTextBox.axaml
@@ -19,7 +19,8 @@
             Value="35" />
             </Style>
             </StackPanel.Styles>-->
-            <TextBox Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit." AcceptsTab="True">
+            <TextBox Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+                     AcceptsTab="True">
                 <TextBox.ContextFlyout>
                     <Flyout>
                         <TextBlock>Custom context flyout</TextBlock>

--- a/src/Experimental/Consolonia.Editor/MainWindow.axaml
+++ b/src/Experimental/Consolonia.Editor/MainWindow.axaml
@@ -28,7 +28,6 @@
             <Button Name="exit" Click="OnExit">E_xit</Button>
         </StackPanel>
 
-        <!-- FontSize="0.7407407407407407" is magic value to fix a bug in AvaloniaEdit when using console fonts.-->
         <AvalonEdit:TextEditor Name="Editor" Grid.Row="2"
                                FontFamily="Cascadia Code,Consolas,Menlo,Monospace"
                                ShowLineNumbers="True"
@@ -37,6 +36,7 @@
                                Background="Transparent">
             <AvalonEdit:TextEditor.Options>
                 <AvalonEdit:TextEditorOptions
+                    AcceptsTab="true"
                     AllowToggleOverstrikeMode = "true"
                     EnableTextDragDrop = "true"
                     EnableRectangularSelection = "False"


### PR DESCRIPTION
* MeasureText returned for \t -1 but we were casting to ushort, making it's width maxvalue
* We were rendering as spaces instead of just advancing the pixel buffer.

We are now aligned 100% with Avalonia behavior, TextBox with AcceptsTab and AvalaloniaEdit both work exactly as we desire.