### PR TITLE
Use RowSpan for PixelBuffer.

### DIFF
--- a/src/Consolonia.Core/Drawing/PixelBufferImplementation/Pixel.cs
+++ b/src/Consolonia.Core/Drawing/PixelBufferImplementation/Pixel.cs
@@ -18,7 +18,7 @@ namespace Consolonia.Core.Drawing.PixelBufferImplementation
     [SuppressMessage("ReSharper", "NotResolvedInText", MessageId = "Color")]
     [SuppressMessage("ReSharper", "NotResolvedInText", MessageId = "Symbol")]
     [DebuggerDisplay(
-        "'{Foreground.Symbol.Text}', Foreground: {Foreground.Color}, Background: {Background.Color}, CaretStyle: {CaretStyle}")]
+        "'{Foreground.Symbol.Character}', Foreground: {Foreground.Color}, Background: {Background.Color}, CaretStyle: {CaretStyle}")]
     public readonly struct Pixel : IEquatable<Pixel>
     {
         private static readonly Lazy<IConsoleColorMode> ConsoleColorMode =


### PR DESCRIPTION
* made PixelBuffer and Pixel Cache single dimension so we can use RowSpan to work on rows.
* Changed loops that are iterating on rows to use RowSpan
* Avalonia Render times seem to be ~8-10% lower
