### PR TITLE
Make WheelMouse and ScrollBars scroll appropriately 

### DIFF
--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryEvents.axaml.cs
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryEvents.axaml.cs
@@ -88,7 +88,7 @@ namespace Consolonia.Gallery.Gallery.GalleryViews
             if (sender is ListBox lb)
             {
                 var vm = lb.SelectedItem as EventViewModel;
-                await MessageBox.ShowDialog(this, vm.Details, vm.Name);
+                await MessageBox.ShowDialog(this, vm.Name, vm.Details);
             }
         }
 

--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryListBox.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryListBox.axaml
@@ -23,19 +23,19 @@
         </StackPanel>
         <StackPanel DockPanel.Dock="Right"
                     Margin="1">
-            <CheckBox IsChecked="{Binding Multiple}">Multiple</CheckBox>
-            <CheckBox IsChecked="{Binding Toggle}">Toggle</CheckBox>
-            <CheckBox IsChecked="{Binding AlwaysSelected}">AlwaysSelected</CheckBox>
-            <CheckBox IsChecked="{Binding AutoScrollToSelectedItem}">AutoScrollToSelectedItem</CheckBox>
+            <CheckBox TabIndex="2" IsChecked="{Binding Multiple}">Multiple</CheckBox>
+            <CheckBox TabIndex="3" IsChecked="{Binding Toggle}">Toggle</CheckBox>
+            <CheckBox TabIndex="4" IsChecked="{Binding AlwaysSelected}">AlwaysSelected</CheckBox>
+            <CheckBox TabIndex="5" IsChecked="{Binding AutoScrollToSelectedItem}">AutoScrollToSelectedItem</CheckBox>
         </StackPanel>
         <StackPanel DockPanel.Dock="Bottom"
                     Orientation="Horizontal"
                     Margin="1">
-            <Button Command="{Binding AddItemCommand}">Add</Button>
-            <Button Command="{Binding RemoveItemCommand}">Remove</Button>
-            <Button Command="{Binding SelectRandomItemCommand}">Select Random Item</Button>
+            <Button TabIndex="6" Command="{Binding AddItemCommand}">Add</Button>
+            <Button TabIndex="7" Command="{Binding RemoveItemCommand}">Remove</Button>
+            <Button TabIndex="8" Command="{Binding SelectRandomItemCommand}">Select Random Item</Button>
         </StackPanel>
-        <ListBox ItemsSource="{Binding Items}"
+        <ListBox TabIndex="0" ItemsSource="{Binding Items}"
                  Selection="{Binding Selection}"
                  AutoScrollToSelectedItem="{Binding AutoScrollToSelectedItem}"
                  SelectionMode="{Binding SelectionMode^}" />

--- a/src/Consolonia.Gallery/View/ControlsListView.axaml
+++ b/src/Consolonia.Gallery/View/ControlsListView.axaml
@@ -63,15 +63,18 @@
             </MenuItem>
         </Menu>
 
-        <DataGrid x:Name="GalleryGrid"
+        <ListBox x:Name="GalleryGrid"
                   DockPanel.Dock="Left"
                   SelectedIndex="0"
+                  Focusable="true"
+                  Width="23"
                   SelectionMode="Single">
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="Name"
-                                    Binding="{Binding Name}" />
-            </DataGrid.Columns>
-        </DataGrid>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Name}" />
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
 
         <Border
             Child="{Binding ElementName=GalleryGrid,Path=SelectedItem, Converter={StaticResource GalleryItemConverter}}"

--- a/src/Consolonia.Themes/Templates/Controls/Helpers/ConsoleScrollContentPresenter.cs
+++ b/src/Consolonia.Themes/Templates/Controls/Helpers/ConsoleScrollContentPresenter.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Reflection;
+using Avalonia;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Utilities;
+
+namespace Consolonia.Themes.Templates.Controls.Helpers
+{
+    // This is workaround for Avalonia issue https://github.com/AvaloniaUI/AvaloniaEdit/issues/540
+    // Wheel mouse values are hard coded.
+    public class ConsoleScrollContentPresenter : ScrollContentPresenter
+    {
+
+        // Cache MethodInfo for private base method to avoid repeated reflection lookup.
+        private static readonly MethodInfo s_snapOffsetMethod =
+            typeof(ScrollContentPresenter).GetMethod("SnapOffset", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
+
+        protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
+        {
+            // base.OnPointerWheelChanged(e);
+            if (Extent.Height > Viewport.Height || Extent.Width > Viewport.Width)
+            {
+                var scrollable = Child as ILogicalScrollable;
+                var isLogical = scrollable?.IsLogicalScrollEnabled == true;
+
+                var x = Offset.X;
+                var y = Offset.Y;
+                var delta = e.Delta;
+
+                // KeyModifiers.Shift should scroll in horizontal direction. This does not work on every platform. 
+                // If Shift-Key is pressed and X is close to 0 we swap the Vector.
+                // NOTE: Changed to also include CTRL
+                if ((e.KeyModifiers == KeyModifiers.Control || e.KeyModifiers == KeyModifiers.Shift) && 
+                    MathUtilities.IsZero(delta.X))
+                {
+                    delta = new Vector(delta.Y, delta.X);
+                }
+                else
+                {
+                    delta = AdjustDeltaForFlowDirection(delta, FlowDirection);
+                }
+
+                if (Extent.Height > Viewport.Height)
+                {
+                    // double height = isLogical ? scrollable!.ScrollSize.Height : 50;
+                    double height = 3;
+                    y += -delta.Y * height;
+                    y = Math.Max(y, 0);
+                    y = Math.Min(y, Extent.Height - Viewport.Height);
+                }
+
+                if (Extent.Width > Viewport.Width)
+                {
+                    //double width = isLogical ? scrollable!.ScrollSize.Width : 50;
+                    double width = 3;
+                    x += -delta.X * width;
+                    x = Math.Max(x, 0);
+                    x = Math.Min(x, Extent.Width - Viewport.Width);
+                }
+
+                var newOffset = (Vector)s_snapOffsetMethod.Invoke(this, new object[] { new Vector(x, y), delta, true })!;
+
+                bool offsetChanged = newOffset != Offset;
+                SetCurrentValue(OffsetProperty, newOffset);
+
+                e.Handled = !IsScrollChainingEnabled || offsetChanged;
+            }
+        }
+        private static Vector AdjustDeltaForFlowDirection(Vector delta, Avalonia.Media.FlowDirection flowDirection)
+        {
+            if (flowDirection == Avalonia.Media.FlowDirection.RightToLeft)
+            {
+                return delta.WithX(-delta.X);
+            }
+            return delta;
+        }
+
+    }
+}

--- a/src/Consolonia.Themes/Templates/Controls/Helpers/SizeConverters.cs
+++ b/src/Consolonia.Themes/Templates/Controls/Helpers/SizeConverters.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace Consolonia.Themes.Templates.Controls.Helpers
+{
+    /// <summary>
+    /// Converts a Size-like object to its Width (double).
+    /// Supports Avalonia.Size, System.Drawing.Size/SizeF, Consolonia.GuiCS.Size (int), and any object exposing a numeric Width property.
+    /// </summary>
+    public sealed class SizeToWidthConverter : IValueConverter
+    {
+        public static readonly IValueConverter Instance = new SizeToWidthConverter();
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Avalonia.Size avaloniaSize && avaloniaSize.Width > 0)
+                return avaloniaSize.Width;
+
+            // fallback
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+            throw new NotSupportedException("SizeToWidthConverter does not support ConvertBack.");
+    }
+
+    /// <summary>
+    /// Converts a Size-like object to its Height (double).
+    /// Supports Avalonia.Size, System.Drawing.Size/SizeF, Consolonia.GuiCS.Size (int), and any object exposing a numeric Height property.
+    /// </summary>
+    public sealed class SizeToHeightConverter : IValueConverter
+    {
+        public static readonly IValueConverter Instance = new SizeToHeightConverter();
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Avalonia.Size avaloniaSize && avaloniaSize.Height > 0)
+                return avaloniaSize.Height;
+
+            // fallback
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+            throw new NotSupportedException("SizeToHeightConverter does not support ConvertBack.");
+    }
+}

--- a/src/Consolonia.Themes/Templates/Controls/ScrollBar.axaml
+++ b/src/Consolonia.Themes/Templates/Controls/ScrollBar.axaml
@@ -1,6 +1,9 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:console="https://github.com/jinek/consolonia">
+    <console:SizeToWidthConverter x:Key="SizeToWidthConverter" />
+    <console:SizeToHeightConverter x:Key="SizeToHeightConverter" />
+    
     <!-- ReSharper disable Xaml.StaticResourceNotResolved -->
     <ControlTheme x:Key="{x:Type ScrollBar}"
                   TargetType="ScrollBar">
@@ -169,10 +172,18 @@
         <Style Selector="^:vertical">
             <Setter Property="Width"
                     Value="1" />
+            <Setter Property="SmallChange"
+                    Value="1" />
+            <Setter Property="LargeChange"
+                    Value="{Binding Viewport, RelativeSource={RelativeSource AncestorType=ScrollViewer},Converter={StaticResource SizeToHeightConverter}}"/>
         </Style>
         <Style Selector="^:horizontal">
             <Setter Property="Height"
                     Value="1" />
+            <Setter Property="SmallChange"
+                    Value="1" />
+            <Setter Property="LargeChange"
+                    Value="{Binding Viewport, RelativeSource={RelativeSource AncestorType=ScrollViewer}, Converter={StaticResource SizeToWidthConverter}}"/>
         </Style>
         <!--<Style Selector="^ /template/ RepeatButton.repeat">
     <Setter Property="Padding" Value="2" />

--- a/src/Consolonia.Themes/Templates/Controls/ScrollViewer.axaml
+++ b/src/Consolonia.Themes/Templates/Controls/ScrollViewer.axaml
@@ -23,7 +23,7 @@
                       RowDefinitions="*,Auto"
                       ColumnDefinitions="*,Auto">
                     <Panel Background="{TemplateBinding Background}">
-                        <ScrollContentPresenter Name="PART_ContentPresenter"
+                        <console:ConsoleScrollContentPresenter Name="PART_ContentPresenter"
                                                 Padding="{TemplateBinding Padding}"
                                                 HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
                                                 VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}"
@@ -37,7 +37,7 @@
                                     CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"
                                     IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}" />
                             </ScrollContentPresenter.GestureRecognizers>
-                        </ScrollContentPresenter>
+                        </console:ConsoleScrollContentPresenter>
                     </Panel>
                     <ScrollBar Name="PART_HorizontalScrollBar"
                                Orientation="Horizontal"
@@ -112,7 +112,7 @@
                             <TextBlock Text="v"
                                        Foreground="{TemplateBinding Foreground}" />
                         </RepeatButton>
-                        <ScrollContentPresenter Name="PART_ContentPresenter"
+                        <console:ConsoleScrollContentPresenter Name="PART_ContentPresenter"
                                                 Padding="{TemplateBinding Padding}"
                                                 HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
                                                 VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}"

--- a/src/Tests/Consolonia.Gallery.Tests/ListBoxTests.cs
+++ b/src/Tests/Consolonia.Gallery.Tests/ListBoxTests.cs
@@ -12,11 +12,11 @@ namespace Consolonia.Gallery.Tests
         [Test]
         public async Task PerformSingleTest()
         {
+            await UITest.AssertHasNoText("Item 27");
+
             await UITest.KeyInput(Key.Tab);
-            await UITest.KeyInput(Key.Tab, RawInputModifiers.Shift);
-            await UITest.KeyInput(Key.Tab, RawInputModifiers.Shift);
             await UITest.KeyInput(Key.PageDown);
-            await UITest.AssertHasText("Item 45");
+            await UITest.AssertHasText("Item 27");
         }
     }
 }


### PR DESCRIPTION
Works around issues in Avalonia/AvaloniaEdit tracked in bug https://github.com/AvaloniaUI/AvaloniaEdit/issues/540

* Fix up/down pageup/pagedown behavior for scroll bars being hard coded to 50/100
 by using ScrollBar theme to size to the scrollviewer viewport via new SizeConverters

* Fix WheelMouse scrolling up and down 50/100 by implementing custom ConsoleScrollContentPresenter which overrides OnWheelMouse handler with appropriate values.

* Fix misc bug found in gallery app of out of order parameters bug when calling Messagebox in GalleryEvents.
* changed gallery list to be listbox because DataGrid has scroll issues deeper than this PR
* Fix Listbox gallery tab order and unit test because it was driving me crazy the way it navigated.