### PR TITLE
tighten up spacing for system buttons on windows/dialogs

### DIFF
--- a/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryIcons.axaml
+++ b/src/Consolonia.Gallery/Gallery/GalleryViews/GalleryIcons.axaml
@@ -31,6 +31,7 @@
                 <TextBlock Width="20"
                            Text="Info" />
                 <TextBlock Text="{StaticResource Icon_Info}" />
+                <TextBlock Text="|" />
             </StackPanel>
             <StackPanel Orientation="Horizontal">
                 <TextBlock Width="20"

--- a/src/Consolonia.Themes/Modern/ModernBase.axaml
+++ b/src/Consolonia.Themes/Modern/ModernBase.axaml
@@ -46,7 +46,7 @@
             <!-- ReSharper disable InconsistentNaming We need to keep same names as in WindowManager-->
             <BoxShadows x:Key="ManagedWindow_BoxShadows">none</BoxShadows>
             <Thickness x:Key='ManagedWindow_BorderThickness'>1</Thickness>
-            <x:Double x:Key="ManagedWindow_SystemIconSpacing">0</x:Double>
+            <x:Double x:Key="ManagedWindow_SystemIconSpacing">-1</x:Double>
             <x:Double x:Key="ManagedWindow_SystemIconSize">1</x:Double>
             <x:Int32 x:Key="ManagedWindow_SizingVector">1</x:Int32>
             <Thickness x:Key='ManagedWindow_TitleMargin'>1 0 0 0</Thickness>


### PR DESCRIPTION
fix gallery icons page, missing bar on info icon

<img width="444" height="118" alt="image" src="https://github.com/user-attachments/assets/c2a1c5ad-1f97-4f8d-a5a7-5f022bb6ad8e" />
