### PR TITLE
Ran profiler: Added cache for emojii's

### DIFF
--- a/src/Consolonia.Core/Drawing/PixelBufferImplementation/Symbol.cs
+++ b/src/Consolonia.Core/Drawing/PixelBufferImplementation/Symbol.cs
@@ -22,6 +22,7 @@ namespace Consolonia.Core.Drawing.PixelBufferImplementation
 
         private static readonly Dictionary<char, string> GlyphCharCache = new();
         private static readonly Dictionary<string, string> GlyphComplexCache = new();
+        private static readonly Dictionary<char, bool> EmojiCharCache = new();
 
         public static readonly Symbol Empty = new();
         public static readonly Symbol Space = new(' ');
@@ -62,7 +63,14 @@ namespace Consolonia.Core.Drawing.PixelBufferImplementation
 
         private static bool ShouldUseEmojiVariation(char ch, byte width)
         {
-            if (Emoji.IsEmoji(new string(ch, 1)))
+            bool isEmoji;
+            lock (EmojiCharCache)
+            {
+                if (!EmojiCharCache.TryGetValue(ch, out isEmoji))
+                    EmojiCharCache[ch] = isEmoji = Emoji.IsEmoji(new string(ch, 1));
+            }
+
+            if (isEmoji)
                 return true;
 
             return width == 2 && char.GetUnicodeCategory(ch) == UnicodeCategory.OtherSymbol;

--- a/src/Consolonia.Core/Helpers/Grapheme.cs
+++ b/src/Consolonia.Core/Helpers/Grapheme.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
 using NeoSmart.Unicode;
@@ -9,6 +10,8 @@ namespace Consolonia.Core.Helpers
     /// </summary>
     public class Grapheme
     {
+        private static readonly ConcurrentDictionary<int, bool> EmojiCache = new();
+
         // sequence of unicode codepoints that produce the glyph
         public string Glyph { get; init; }
 
@@ -115,7 +118,7 @@ namespace Consolonia.Core.Helpers
             if (IsVariationSelector(rune))
                 return RuneType.VariationSelector;
 
-            if (Emoji.IsEmoji(rune.ToString()))
+            if (EmojiCache.GetOrAdd(rune.Value, static v => Emoji.IsEmoji(new Rune(v).ToString())))
                 return RuneType.Emoji;
 
             return RuneType.Regular;


### PR DESCRIPTION
What was changed:
1. ClassifyRune(Rune) (Grapheme.cs) — Added a ConcurrentDictionary<int, bool> EmojiCache static field. The Emoji.IsEmoji(rune.ToString()) call, which allocates a string, an async iterator state machine (Codepoint.<AsUtf8>d__8), and byte arrays on every single rune, now only runs once per unique codepoint value and caches the result.
2. ShouldUseEmojiVariation(char, byte) (Symbol.cs) — Added a Dictionary<char, bool> EmojiCharCache (locked, consistent with the existing GlyphCharCache pattern) so the Emoji.IsEmoji(new string(ch, 1)) call is equally cached per character. These caches are warm quickly since the set of unique characters in a typical TUI application is small and finite — after the first render pass, almost zero allocations occur from emoji detection. 

The improvements are massive:

|Metric |Before |After |Improvement|
|----|---|---|---|
|ParseSimpleText() mean |23.2 ms |1.34 ms |~17× faster|
|ParseEmojiText() mean |9.5 ms |0.75 ms |~13× faster|
|ParseMixedText() mean |18.7 ms |0.89 ms |~21× faster|
|ParseSimpleText() allocated |80.71 KB |5.96 KB ~|14× less memory |
|Codepoint.<AsUtf8>d__8 allocations |1,495,040 / 59.8 MB |near zero |after warm-up eliminated|